### PR TITLE
feat(Rentab v0.2): Итерация 3 — формы UI и доработки модулей

### DIFF
--- a/Rentab_VKR_v0.2/modules/calculator.py
+++ b/Rentab_VKR_v0.2/modules/calculator.py
@@ -8,13 +8,15 @@ Rentab v0.2 — модуль финансовых расчётов.
 
 from __future__ import annotations
 
+from modules.team import JUNIOR_ROLES, SENIOR_ROLES
+
 
 # ---------------------------------------------------------------------------
 # Тип данных для описания члена команды (используется внутри модуля)
 # ---------------------------------------------------------------------------
 # team_member: dict со следующими полями:
 #   "name"         : str   — имя/ФИО сотрудника
-#   "role"         : str   — одна из: "Partner", "Senior", "Associate", "Junior"
+#   "role"         : str   — значение EmployeeRole (см. modules.team)
 #   "billing_rate" : float — внешняя ставка для клиента (руб./час или тенге/час)
 #   "cost_rate"    : float — себестоимость часа сотрудника (ФОТ + соц. отчисления)
 #   "hours"        : float — часы, запланированные на проект
@@ -52,32 +54,34 @@ def blended_rate(team: list[dict]) -> float:
 def leverage(team: list[dict]) -> float:
     """Коэффициент рычага команды (Leverage).
 
-    Формула: Σ часов (Associate + Junior) / Σ часов (Partner + Senior)
+    Формула: Σ часов (младшие) / Σ часов (старшие)
 
     Leverage — индикатор эффективности структуры PSF-команды. Высокий Leverage
     означает, что бо́льшую часть работы выполняют менее дорогие сотрудники под
     надзором партнёров, что улучшает маржинальность.
 
+    Классификация ролей на старших / младших берётся из модуля team
+    (SENIOR_ROLES и JUNIOR_ROLES), чтобы оба модуля использовали один источник
+    истины и при добавлении роли не требовалось править эту функцию.
+
     Args:
         team: Список словарей, каждый содержит "role" (str) и "hours" (float).
-              Допустимые значения role: "Partner", "Senior", "Associate", "Junior".
+              Значения role должны попадать либо в team.SENIOR_ROLES,
+              либо в team.JUNIOR_ROLES.
 
     Returns:
         Значение Leverage. Возвращает 0.0, если нет старших сотрудников.
 
     Example:
         >>> team = [
-        ...     {"role": "Partner",   "hours": 10},
-        ...     {"role": "Associate", "hours": 40},
+        ...     {"role": "Партнёр",       "hours": 10},
+        ...     {"role": "Младший юрист", "hours": 40},
         ... ]
         >>> leverage(team)
         4.0
     """
-    senior_roles = {"Partner", "Senior"}
-    junior_roles = {"Associate", "Junior"}
-
-    senior_hours = sum(m["hours"] for m in team if m["role"] in senior_roles)
-    junior_hours = sum(m["hours"] for m in team if m["role"] in junior_roles)
+    senior_hours = sum(m["hours"] for m in team if m["role"] in SENIOR_ROLES)
+    junior_hours = sum(m["hours"] for m in team if m["role"] in JUNIOR_ROLES)
 
     if senior_hours == 0:
         return 0.0

--- a/Rentab_VKR_v0.2/modules/expenses.py
+++ b/Rentab_VKR_v0.2/modules/expenses.py
@@ -90,10 +90,20 @@ class Expense:
     def from_dict(cls, data: dict) -> "Expense":
         """Создаёт Expense из словаря (например, прочитанного из JSON).
 
-        Недостающие поля заполняются значениями по умолчанию.
+        Недостающие поля заполняются значениями по умолчанию — это даёт
+        устойчивость к неполным записям в JSON-шаблонах и в session_state.
+
+        Args:
+            data: Словарь с произвольным набором полей Expense. Единственное
+                  поле без «разумного» дефолта — name, но и для него мы
+                  подставляем пустую строку, чтобы не падать на битых записях
+                  (проверку на непустое имя оставляем вызывающему коду).
+
+        Returns:
+            Новый Expense со всеми подстановками дефолтов.
         """
         return cls(
-            name=str(data["name"]),
+            name=str(data.get("name", "")),
             category=str(data.get("category", "overhead")),
             amount=float(data.get("amount", 0.0)),
             currency=str(data.get("currency", "RUB")),
@@ -127,14 +137,31 @@ class ExpenseManager:
     2. project_expenses — прямые расходы по конкретному проекту: пошлины,
        командировки и прочее.
 
+    Также хранит `billable_hours_per_month` — среднее число оплачиваемых
+    часов всей фирмы за месяц. Используется как знаменатель в формуле
+    overhead_rate = Σ(monthly overheads) / billable_hours_per_month,
+    а через неё — в аллокации накладных на конкретный проект.
+
     По умолчанию оба списка пусты: расходы проекта добавляются, только
     если они реально есть в задаче.
     """
 
-    def __init__(self) -> None:
-        """Создаёт пустой менеджер расходов."""
+    def __init__(self, billable_hours_per_month: float = 160.0) -> None:
+        """Создаёт пустой менеджер расходов.
+
+        Args:
+            billable_hours_per_month: Плановый объём оплачиваемых часов
+                всей фирмы в месяц. 160 часов — средняя норма при полной
+                загрузке одного юриста (8 ч × ~20 рабочих дней).
+                Можно переопределить атрибутом позднее.
+        """
+        if billable_hours_per_month <= 0:
+            raise ValueError(
+                f"billable_hours_per_month должно быть > 0, получено: {billable_hours_per_month}"
+            )
         self._overheads: list[Expense] = []
         self._project_expenses: list[Expense] = []
+        self.billable_hours_per_month: float = float(billable_hours_per_month)
 
     # -- накладные фирмы ----------------------------------------------------
 
@@ -187,27 +214,28 @@ class ExpenseManager:
         return self.total_overheads_monthly() / billable_hours_per_month
 
     def get_overheads_allocated(self, direct_costs: float) -> float:
-        """Аллоцированные накладные в абсолютном выражении.
+        """Аллоцированные накладные на проект в абсолютном выражении.
 
-        Поддерживается «прямая» аллокация: доля накладных, приходящаяся на
-        проект, трактуется как пропорция от прямых трудозатрат. Это упрощённый
-        вариант, полезный когда billable_hours_per_month ещё не задано.
+        Формула (прямая аллокация):
+            overhead_rate = total_overheads_monthly() / billable_hours_per_month
+            allocated     = overhead_rate × direct_costs
 
-        Для основной модели (по часам) используйте calculate_overhead_rate()
-        и умножьте на фактические часы проекта.
+        direct_costs здесь — любой показатель объёма работы по проекту,
+        к которому мы хотим привязать накладные (обычно прямые трудозатраты
+        или часы). Ставка берётся как доля месячных накладных на единицу
+        стандартного оплачиваемого часа — см. self.billable_hours_per_month.
 
         Args:
-            direct_costs: Прямые трудозатраты по проекту.
+            direct_costs: База для аллокации (трудозатраты либо часы по проекту).
 
         Returns:
-            Сумма накладных, отнесённых на проект. Ставка-множитель берётся
-            как отношение месячных накладных к прямым затратам-базису —
-            поэтому при нулевом direct_costs возвращается 0.0.
+            Сумма накладных, отнесённых на проект. 0.0 при нулевой базе
+            или при пустом списке накладных.
         """
         if direct_costs <= 0:
             return 0.0
-        monthly = self.total_overheads_monthly()
-        return monthly  # простое отнесение месячного объёма (как fallback)
+        overhead_rate = self.total_overheads_monthly() / self.billable_hours_per_month
+        return overhead_rate * direct_costs
 
     # -- расходы проекта ----------------------------------------------------
 

--- a/Rentab_VKR_v0.2/modules/jurisdiction.py
+++ b/Rentab_VKR_v0.2/modules/jurisdiction.py
@@ -53,6 +53,15 @@ TAX_RATES_RF_2026: dict[str, Any] = {
         "standard": 0.30,   # стандартный тариф
         "zero": 0.0,        # для плательщиков АУСН
     },
+    # НДФЛ (упрощённая двухступенчатая модель по запросу ВКР):
+    # 13% до порога, 15% сверх. Порог трактуется как годовая сумма,
+    # т.е. для применения прогрессии в gross_salary нужно передавать
+    # годовой (а не месячный) доход работника.
+    "NDFL": {
+        "base_rate": 0.13,
+        "high_rate": 0.15,
+        "threshold": 5_000_000,   # руб./год
+    },
 }
 
 
@@ -340,21 +349,25 @@ class TaxCalculator:
         raise ValueError(f"Неизвестная страна: {country!r}")
 
     def add_payroll_taxes(self, gross_salary: float) -> dict:
-        """Рассчитывает зарплатные налоги и взносы (только для РК).
+        """Рассчитывает зарплатные налоги и взносы (РФ и РК).
 
         Метод раскладывает начисленную («грязную») зарплату на:
-        - суммы, удерживаемые у работника (ОПВ/ИПН/ВОСМС);
-        - суммы, уплачиваемые работодателем сверху (ООСМС/СО/ОПВР).
+        - суммы, удерживаемые у работника (РФ: НДФЛ; РК: ОПВ/ИПН/ВОСМС);
+        - суммы, уплачиваемые работодателем сверху
+          (РФ: страховые взносы; РК: ООСМС/СО/ОПВР).
 
         Используется при расчёте cost_rate сотрудника в Setup: полная
         себестоимость часа = (зарплата + взносы работодателя) / часы.
 
         Args:
-            gross_salary: Начисленная зарплата работника в тенге.
+            gross_salary: Начисленная зарплата работника.
+                          Для РФ — трактуется как годовая (для применения
+                          порога НДФЛ 5 млн руб.); для РК — месячная.
 
         Returns:
             Словарь:
             {
+                "country"               : str,             # "RF" | "KZ"
                 "gross_salary"          : float,           # «грязная» зарплата
                 "employee"              : dict[str,float], # что удержали у работника
                 "employer"              : dict[str,float], # что платит работодатель
@@ -365,13 +378,68 @@ class TaxCalculator:
             }
 
         Raises:
-            ValueError: Если режим не относится к РК.
+            ValueError: Если юрисдикция не поддерживается или gross_salary < 0.
         """
-        if self.params["country"] != "KZ":
-            raise ValueError("add_payroll_taxes реализован только для РК")
         if gross_salary < 0:
             raise ValueError(f"gross_salary не может быть отрицательной: {gross_salary}")
 
+        country = self.params["country"]
+        if country == "RF":
+            return self._payroll_rf(gross_salary)
+        if country == "KZ":
+            return self._payroll_kz(gross_salary)
+        raise ValueError(f"add_payroll_taxes: неизвестная юрисдикция {country!r}")
+
+    def _payroll_rf(self, gross_salary: float) -> dict:
+        """Зарплатные налоги по РФ (упрощённая модель НДФЛ 13%/15%).
+
+        Работодатель платит сверху страховые взносы: 30% (standard) либо
+        0% (zero) — для плательщиков АУСН. Тариф читается из self.params
+        (ключ "social_contributions"); если ключа нет — берётся "standard".
+
+        НДФЛ с работника — двухступенчатая прогрессия из TAX_RATES_RF_2026:
+        base_rate до threshold, high_rate — со сверхпороговой части.
+        """
+        ndfl = TAX_RATES_RF_2026["NDFL"]
+        sc_rates = TAX_RATES_RF_2026["SOCIAL_CONTRIBUTIONS"]
+
+        sc_choice = self.params.get("social_contributions", "standard")
+        if sc_choice not in sc_rates:
+            raise ValueError(
+                f"Неизвестный тариф страховых взносов: {sc_choice!r}. "
+                f"Допустимые: {list(sc_rates)}"
+            )
+        sc_rate = sc_rates[sc_choice]
+
+        threshold = ndfl["threshold"]
+        if gross_salary <= threshold:
+            ndfl_amount = gross_salary * ndfl["base_rate"]
+        else:
+            ndfl_amount = (
+                threshold * ndfl["base_rate"]
+                + (gross_salary - threshold) * ndfl["high_rate"]
+            )
+
+        insurance = gross_salary * sc_rate
+
+        employee = {"НДФЛ": ndfl_amount}
+        employer = {"Страховые взносы": insurance}
+        emp_total = sum(employee.values())
+        er_total = sum(employer.values())
+
+        return {
+            "country": "RF",
+            "gross_salary": gross_salary,
+            "employee": employee,
+            "employer": employer,
+            "employee_total": emp_total,
+            "employer_total": er_total,
+            "net_to_employee": gross_salary - emp_total,
+            "total_employer_cost": gross_salary + er_total,
+        }
+
+    def _payroll_kz(self, gross_salary: float) -> dict:
+        """Зарплатные налоги и взносы по РК (ОПВ/ИПН/ВОСМС + ООСМС/СО/ОПВР)."""
         emp_rates = TAX_RATES_KZ_2026["PAYROLL_EMPLOYEE"]
         er_rates = TAX_RATES_KZ_2026["PAYROLL_EMPLOYER"]
 
@@ -381,6 +449,7 @@ class TaxCalculator:
         er_total = sum(employer.values())
 
         return {
+            "country": "KZ",
             "gross_salary": gross_salary,
             "employee": employee,
             "employer": employer,

--- a/Rentab_VKR_v0.2/modules/team.py
+++ b/Rentab_VKR_v0.2/modules/team.py
@@ -20,19 +20,24 @@ class EmployeeRole(str, Enum):
     """Роли сотрудников в юридической фирме (иерархия PSF).
 
     Порядок ролей отражает типичную иерархию профессиональной сервисной фирмы:
-    Partner > Senior > Associate > Junior.
+    Партнёр > Старший юрист > Младший юрист > Стажёр.
+
+    Значения — русские, потому что эти строки напрямую показываются в UI
+    и сохраняются в session_state/JSON. Любой новой роли достаточно
+    добавить сюда и (при необходимости) классифицировать в SENIOR_ROLES
+    или JUNIOR_ROLES — остальные модули подхватят автоматически.
     """
 
-    PARTNER = "Partner"
-    SENIOR = "Senior"
-    ASSOCIATE = "Associate"
-    JUNIOR = "Junior"
+    PARTNER = "Партнёр"
+    SENIOR = "Старший юрист"
+    ASSOCIATE = "Младший юрист"
+    JUNIOR = "Стажёр"
 
 
 # Список строковых значений для использования в st.selectbox / st.data_editor
 ROLE_OPTIONS: list[str] = [role.value for role in EmployeeRole]
 
-# Разделение ролей для расчёта Leverage
+# Разделение ролей для расчёта Leverage (используется calculator.leverage()).
 SENIOR_ROLES: set[str] = {EmployeeRole.PARTNER.value, EmployeeRole.SENIOR.value}
 JUNIOR_ROLES: set[str] = {EmployeeRole.ASSOCIATE.value, EmployeeRole.JUNIOR.value}
 
@@ -86,7 +91,11 @@ def default_team_df() -> pd.DataFrame:
     return pd.DataFrame(
         {
             "Имя": ["Иванов А.", "Петрова М.", "Сидоров К."],
-            "Роль": ["Partner", "Senior", "Associate"],
+            "Роль": [
+                EmployeeRole.PARTNER.value,
+                EmployeeRole.SENIOR.value,
+                EmployeeRole.ASSOCIATE.value,
+            ],
             "Ставка (Billing)": [15000.0, 10000.0, 6000.0],
             "Себестоимость (Cost)": [8000.0, 5500.0, 3500.0],
         }

--- a/Rentab_VKR_v0.2/pages/01_Setup.py
+++ b/Rentab_VKR_v0.2/pages/01_Setup.py
@@ -1,203 +1,406 @@
 """
-Rentab v0.2 — страница 01: Настройка среды.
+Rentab v0.2 — страница 01: Настройка среды (итерация 3).
 
-Позволяет пользователю задать:
-1. Юрисдикцию и налоговый режим (пресет TaxCalculator).
-2. Состав команды (billing rate / cost rate).
-3. Накладные расходы фирмы (редактируемый шаблон из firm_expenses.json).
+Страница организована в три вкладки (st.tabs):
+1. «Юрисдикция и налоги» — выбор РФ / РК / Оба и параметров налогового режима.
+2. «Команда» — форма добавления сотрудников с удалением по строкам.
+3. «Расходы фирмы» — редактируемая таблица накладных + расчёт overhead_rate.
 
-Все данные сохраняются в st.session_state и доступны на остальных страницах.
+Данные сохраняются в st.session_state под согласованными ключами:
+    jurisdiction_params       — dict (см. блок «Юрисдикция» ниже)
+    team                      — list[dict] ({name, role, billing_rate, cost_rate})
+    firm_expenses             — list[dict] (сериализованные Expense-ы)
+    billable_hours_per_month  — float
+    exchange_rate_rub_per_kzt — float (только в режиме «Оба»)
+
+Хардкоды ставок не используются — все параметры берутся из
+modules.jurisdiction (TAX_RATES_RF_2026 / TAX_RATES_KZ_2026).
 """
+
+from __future__ import annotations
 
 from pathlib import Path
 
+import pandas as pd
 import streamlit as st
 
+from modules.expenses import Expense, ExpenseManager, load_firm_overheads
 from modules.jurisdiction import (
     COUNTRY_NAMES,
-    get_currency_code,
-    get_currency_symbol,
-    get_preset,
-    get_presets_by_country,
+    CURRENCY_SYMBOLS,
+    TAX_RATES_RF_2026,
+    TAX_RATES_KZ_2026,
 )
-from modules.team import ROLE_OPTIONS, default_team_df, team_from_editor
-from modules.expenses import (
-    ExpenseManager,
-    df_to_overheads,
-    load_firm_overheads,
-    overheads_to_df,
-)
+from modules.team import EmployeeRole, ROLE_OPTIONS
 
 # ---------------------------------------------------------------------------
-# Конфигурация пути к данным
+# Константы страницы
 # ---------------------------------------------------------------------------
 DATA_DIR = Path(__file__).parent.parent / "data"
 FIRM_EXPENSES_PATH = DATA_DIR / "firm_expenses.json"
 
+# Варианты юрисдикции в радио-группе
+JURISDICTION_OPTIONS: dict[str, str] = {
+    "RF": "Только РФ",
+    "KZ": "Только РК",
+    "Both": "Оба (РФ + РК)",
+}
+
+# Список режимов РФ (ключи) — для st.radio. Человекочитаемые подписи
+# собираем из TAX_RATES_RF_2026 динамически, без дублирования.
+RF_REGIME_KEYS: list[str] = ["USN", "OSNO", "NPD"]
+RF_REGIME_LABELS: dict[str, str] = {
+    "USN": "УСН",
+    "OSNO": "ОСНО",
+    "NPD": "НПД (самозанятость)",
+}
+
 # ---------------------------------------------------------------------------
-# Заголовок
+# Инициализация session_state дефолтами (чтобы страница не падала
+# при повторном заходе или навигации между вкладками)
+# ---------------------------------------------------------------------------
+st.session_state.setdefault("team", [])
+st.session_state.setdefault("firm_expenses", [])
+st.session_state.setdefault("billable_hours_per_month", 160.0)
+st.session_state.setdefault("exchange_rate_rub_per_kzt", 0.18)  # индикативно
+
+# ---------------------------------------------------------------------------
+# Заголовок страницы
 # ---------------------------------------------------------------------------
 st.title("⚙️ Настройка среды")
-st.markdown("Задайте юрисдикцию, налоговый режим, состав команды и накладные фирмы.")
+st.caption("Заполните три вкладки: юрисдикция, команда, накладные фирмы.")
 
-# ---------------------------------------------------------------------------
-# Блок 1: Юрисдикция и налоговый режим
-# ---------------------------------------------------------------------------
-st.subheader("1. Юрисдикция и налоговый режим")
+tab_jur, tab_team, tab_exp = st.tabs(
+    ["🏛️ Юрисдикция и налоги", "👥 Команда", "🧾 Расходы фирмы"]
+)
 
-col_country, col_regime = st.columns(2)
-
-with col_country:
-    country = st.selectbox(
-        "Страна",
-        options=list(COUNTRY_NAMES.keys()),
-        format_func=lambda c: COUNTRY_NAMES[c],
+# ===========================================================================
+# ВКЛАДКА 1 — ЮРИСДИКЦИЯ И НАЛОГИ
+# ===========================================================================
+with tab_jur:
+    st.subheader("Юрисдикция")
+    jurisdiction = st.radio(
+        "Где работает фирма?",
+        options=list(JURISDICTION_OPTIONS.keys()),
+        format_func=lambda k: JURISDICTION_OPTIONS[k],
+        horizontal=True,
+        key="jurisdiction_choice",
     )
 
-presets = get_presets_by_country(country)
-currency_symbol = get_currency_symbol(country)
-currency_code = get_currency_code(country)
+    # --------- параметры РФ ---------
+    rf_params: dict | None = None
+    if jurisdiction in ("RF", "Both"):
+        st.markdown("### 🇷🇺 Параметры РФ")
+        rf_regime = st.radio(
+            "Налоговый режим (РФ)",
+            options=RF_REGIME_KEYS,
+            format_func=lambda k: RF_REGIME_LABELS[k],
+            horizontal=True,
+            key="rf_regime_choice",
+        )
 
-with col_regime:
-    preset_key = st.selectbox(
-        "Налоговый режим",
-        options=[p["key"] for p in presets],
-        format_func=lambda k: next(p["label"] for p in presets if p["key"] == k),
+        rf_params = {"country": "RF", "regime": rf_regime}
+
+        if rf_regime == "USN":
+            col_obj, col_vat, col_sc = st.columns(3)
+            with col_obj:
+                usn_object = st.selectbox(
+                    "Объект налогообложения",
+                    options=list(TAX_RATES_RF_2026["USN"].keys()),
+                    format_func=lambda o: {
+                        "income": "Доходы (6%)",
+                        "income_minus_expenses": "Доходы − расходы (15%)",
+                    }[o],
+                    key="rf_usn_object",
+                )
+            with col_vat:
+                usn_vat = st.selectbox(
+                    "НДС (с 2026 г.)",
+                    options=list(TAX_RATES_RF_2026["USN_VAT"].keys()),
+                    format_func=lambda v: {"none": "Без НДС", "5%": "5%", "7%": "7%"}[v],
+                    key="rf_usn_vat",
+                )
+            with col_sc:
+                usn_sc = st.selectbox(
+                    "Страховые взносы",
+                    options=list(TAX_RATES_RF_2026["SOCIAL_CONTRIBUTIONS"].keys()),
+                    format_func=lambda s: {
+                        "standard": "Стандарт (30%)",
+                        "zero": "АУСН (0%)",
+                    }[s],
+                    key="rf_usn_sc",
+                )
+            rf_params.update(
+                object=usn_object,
+                vat=usn_vat,
+                social_contributions=usn_sc,
+            )
+
+        elif rf_regime == "OSNO":
+            st.info(
+                "На ОСНО ставки фиксированные по НК РФ — редактирование не требуется.",
+                icon="ℹ️",
+            )
+            col_a, col_b, col_c = st.columns(3)
+            col_a.metric("НДС", f"{TAX_RATES_RF_2026['OSNO']['vat'] * 100:.0f}%")
+            col_b.metric("Налог на прибыль", f"{TAX_RATES_RF_2026['OSNO']['profit'] * 100:.0f}%")
+            col_c.metric(
+                "Страховые взносы",
+                f"{TAX_RATES_RF_2026['SOCIAL_CONTRIBUTIONS']['standard'] * 100:.0f}%",
+            )
+            rf_params["social_contributions"] = "standard"
+
+        elif rf_regime == "NPD":
+            npd_client = st.radio(
+                "Тип клиентов",
+                options=list(TAX_RATES_RF_2026["NPD"].keys()),
+                format_func=lambda c: {
+                    "individual": "Физлица (4%)",
+                    "legal_entity": "Юрлица / ИП (6%)",
+                }[c],
+                horizontal=True,
+                key="rf_npd_client",
+            )
+            rf_params["client_type"] = npd_client
+
+    # --------- параметры РК ---------
+    kz_params: dict | None = None
+    if jurisdiction in ("KZ", "Both"):
+        st.markdown("### 🇰🇿 Параметры РК (ОУР)")
+        col_form, col_vat = st.columns(2)
+        with col_form:
+            kz_form = st.radio(
+                "Форма организации",
+                options=["too", "ip"],
+                format_func=lambda f: {"too": "ТОО (КПН 20%)", "ip": "ИП (ИПН 10%)"}[f],
+                horizontal=True,
+                key="kz_form_choice",
+            )
+        with col_vat:
+            kz_vat = st.radio(
+                "НДС",
+                options=list(TAX_RATES_KZ_2026["VAT"].keys()),
+                format_func=lambda v: {"none": "Без НДС", "16%": "16%"}[v],
+                horizontal=True,
+                key="kz_vat_choice",
+            )
+        kz_params = {
+            "country": "KZ",
+            "regime": "OUR",
+            "form": kz_form,
+            "vat": kz_vat,
+        }
+
+    # --------- обменный курс в режиме «Оба» ---------
+    exchange_rate: float | None = None
+    if jurisdiction == "Both":
+        st.markdown("### 💱 Обменный курс")
+        exchange_rate = st.number_input(
+            "RUB за 1 KZT (например, 0.18 → 1 ₸ ≈ 0.18 ₽)",
+            min_value=0.0001,
+            value=float(st.session_state["exchange_rate_rub_per_kzt"]),
+            step=0.01,
+            format="%.4f",
+            key="exchange_rate_input",
+        )
+        st.session_state["exchange_rate_rub_per_kzt"] = exchange_rate
+
+    # --------- итоговая структура jurisdiction_params ---------
+    jurisdiction_params: dict = {
+        "jurisdiction": jurisdiction,
+        "rf": rf_params,
+        "kz": kz_params,
+        "exchange_rate_rub_per_kzt": exchange_rate if jurisdiction == "Both" else None,
+    }
+    st.session_state["jurisdiction_params"] = jurisdiction_params
+
+    # --------- сводка ---------
+    with st.expander("Текущие настройки (session_state)", expanded=False):
+        st.json(jurisdiction_params)
+
+
+# ===========================================================================
+# ВКЛАДКА 2 — КОМАНДА
+# ===========================================================================
+with tab_team:
+    st.subheader("Состав команды")
+    st.caption(
+        "cost_rate должен включать ФОТ и долю накладных — себестоимость часа "
+        "сотрудника с учётом всех обязательных отчислений и аллоцированных "
+        "административных расходов."
     )
 
-preset = get_preset(preset_key)
+    # --- форма добавления ---
+    with st.form("add_member_form", clear_on_submit=True):
+        col_name, col_role = st.columns([2, 1])
+        with col_name:
+            new_name = st.text_input("Имя / ФИО", placeholder="Иванов И.")
+        with col_role:
+            new_role = st.selectbox("Роль", options=ROLE_OPTIONS)
 
-st.info(
-    f"**{COUNTRY_NAMES[country]}** · {preset['label']} · Валюта: **{currency_symbol}**",
-    icon="🏛️",
-)
+        col_bill, col_cost = st.columns(2)
+        with col_bill:
+            new_billing = st.number_input(
+                "Billing rate (ставка для клиента)",
+                min_value=0.0,
+                value=0.0,
+                step=500.0,
+                format="%.0f",
+            )
+        with col_cost:
+            new_cost = st.number_input(
+                "Cost rate (себестоимость часа)",
+                min_value=0.0,
+                value=0.0,
+                step=500.0,
+                format="%.0f",
+            )
 
-# Сохраняем в session_state
-st.session_state["country"] = country
-st.session_state["currency"] = currency_symbol
-st.session_state["currency_code"] = currency_code
-st.session_state["regime_preset_key"] = preset_key
-st.session_state["regime_preset_label"] = preset["label"]
-st.session_state["regime_params"] = preset["params"]
+        submitted = st.form_submit_button("➕ Добавить сотрудника")
+        if submitted:
+            if not new_name.strip():
+                st.error("Имя не может быть пустым.")
+            else:
+                st.session_state["team"].append(
+                    {
+                        "name": new_name.strip(),
+                        "role": new_role,
+                        "billing_rate": float(new_billing),
+                        "cost_rate": float(new_cost),
+                    }
+                )
+                st.success(f"Добавлен(а): {new_name}")
 
-st.markdown("---")
+    # --- текущая команда ---
+    st.markdown("### Текущая команда")
+    team_list: list[dict] = st.session_state["team"]
+    if not team_list:
+        st.info("Пока никого нет. Добавьте первого сотрудника выше.")
+    else:
+        for idx, member in enumerate(team_list):
+            c1, c2, c3, c4, c5 = st.columns([2, 1.2, 1, 1, 0.5])
+            c1.write(f"**{member['name']}**")
+            c2.write(member["role"])
+            c3.write(f"{member['billing_rate']:,.0f}")
+            c4.write(f"{member['cost_rate']:,.0f}")
+            if c5.button("🗑", key=f"del_member_{idx}", help="Удалить"):
+                st.session_state["team"].pop(idx)
+                st.rerun()
 
-# ---------------------------------------------------------------------------
-# Блок 2: Состав команды
-# ---------------------------------------------------------------------------
-st.subheader("2. Состав команды")
-st.caption(
-    "Заполните ставки сотрудников. "
-    "Ставка (Billing) — стоимость часа для клиента. "
-    "Себестоимость (Cost) — ФОТ + соцотчисления."
-)
+        st.caption(
+            f"Всего: {len(team_list)} сотрудников · "
+            "столбцы: Имя · Роль · Billing · Cost"
+        )
 
-if "team_df" not in st.session_state:
-    st.session_state["team_df"] = default_team_df()
 
-team_df = st.data_editor(
-    st.session_state["team_df"],
-    num_rows="dynamic",
-    column_config={
-        "Имя": st.column_config.TextColumn("Имя / ФИО", required=True),
-        "Роль": st.column_config.SelectboxColumn(
-            "Роль",
-            options=ROLE_OPTIONS,
-            required=True,
-        ),
-        "Ставка (Billing)": st.column_config.NumberColumn(
-            f"Ставка, {currency_symbol}/ч",
-            min_value=0.0,
-            format="%.0f",
-        ),
-        "Себестоимость (Cost)": st.column_config.NumberColumn(
-            f"Себестоимость, {currency_symbol}/ч",
-            min_value=0.0,
-            format="%.0f",
-        ),
-    },
-    hide_index=True,
-    use_container_width=True,
-    key="team_editor",
-)
+# ===========================================================================
+# ВКЛАДКА 3 — РАСХОДЫ ФИРМЫ
+# ===========================================================================
+with tab_exp:
+    st.subheader("Накладные расходы фирмы (Overheads)")
+    st.caption(
+        "Ставка накладных = Σ(monthly overheads) / billable_hours_per_month. "
+        "Аллоцируется на проект пропорционально отработанным часам."
+    )
 
-st.session_state["team_df"] = team_df
-st.session_state["team"] = team_from_editor(team_df)
+    # --- загрузка шаблона ---
+    col_tpl, col_clear = st.columns([1, 1])
+    if col_tpl.button("📥 Загрузить типовой шаблон"):
+        try:
+            loaded = load_firm_overheads(FIRM_EXPENSES_PATH)
+            st.session_state["firm_expenses"] = [e.to_dict() for e in loaded]
+            st.success(f"Загружено {len(loaded)} типовых статей.")
+            st.rerun()
+        except FileNotFoundError as exc:
+            st.error(str(exc))
 
-if not team_df.empty:
-    st.success(f"Сотрудников в команде: **{len(team_df)}**")
+    if col_clear.button("🧹 Очистить список"):
+        st.session_state["firm_expenses"] = []
+        st.rerun()
 
-st.markdown("---")
+    # --- редактируемая таблица ---
+    rows = st.session_state["firm_expenses"]
+    if not rows:
+        df_empty = pd.DataFrame(
+            columns=["Название", "Сумма", "Период", "Валюта"]
+        )
+        df_edit_src = df_empty
+    else:
+        df_edit_src = pd.DataFrame(
+            [
+                {
+                    "Название": r.get("name", ""),
+                    "Сумма": float(r.get("amount", 0.0)),
+                    "Период": r.get("period", "monthly"),
+                    "Валюта": r.get("currency", "RUB"),
+                }
+                for r in rows
+            ]
+        )
 
-# ---------------------------------------------------------------------------
-# Блок 3: Накладные расходы фирмы (Overheads)
-# ---------------------------------------------------------------------------
-st.subheader("3. Накладные расходы фирмы (Overheads)")
-st.caption(
-    "Накладные аллоцируются на проект пропорционально часам. "
-    "Ставка накладных = Σ(monthly overheads) / оплачиваемые часы в месяц."
-)
+    edited = st.data_editor(
+        df_edit_src,
+        num_rows="dynamic",
+        column_config={
+            "Название": st.column_config.TextColumn(required=True),
+            "Сумма": st.column_config.NumberColumn(min_value=0.0, format="%.0f"),
+            "Период": st.column_config.SelectboxColumn(
+                options=["monthly", "annual", "one-time"], required=True
+            ),
+            "Валюта": st.column_config.SelectboxColumn(
+                options=["RUB", "KZT", "USD"], required=True
+            ),
+        },
+        hide_index=True,
+        use_container_width=True,
+        key="overheads_editor",
+    )
 
-# Загружаем шаблон Expense-ов из firm_expenses.json
-if "overheads_df" not in st.session_state:
-    try:
-        overheads_initial = load_firm_overheads(FIRM_EXPENSES_PATH)
-    except FileNotFoundError:
-        overheads_initial = []
-    st.session_state["overheads_df"] = overheads_to_df(overheads_initial)
+    # Сохраняем обратно в session_state как list[dict] Expense-совместимый
+    st.session_state["firm_expenses"] = [
+        {
+            "name": str(row["Название"]),
+            "category": "overhead",
+            "amount": float(row["Сумма"]),
+            "currency": str(row["Валюта"]),
+            "period": str(row["Период"]),
+            "billable": False,
+        }
+        for _, row in edited.iterrows()
+        if str(row["Название"]).strip()
+    ]
 
-if "billable_hours_month" not in st.session_state:
-    st.session_state["billable_hours_month"] = 120.0
-
-col_hours, _ = st.columns([1, 3])
-with col_hours:
+    # --- плановые оплачиваемые часы в месяц ---
+    st.markdown("### Оплачиваемые часы")
     billable_hours = st.number_input(
-        "Плановые оплачиваемые часы в месяц",
+        "Среднее кол-во оплачиваемых часов в месяц по всей фирме",
         min_value=1.0,
-        value=float(st.session_state["billable_hours_month"]),
+        value=float(st.session_state["billable_hours_per_month"]),
         step=10.0,
+        help="Используется как знаменатель в формуле overhead_rate. "
+        "Дефолт 160 ч ≈ 8 ч × 20 рабочих дней для одного юриста.",
     )
-    st.session_state["billable_hours_month"] = billable_hours
+    st.session_state["billable_hours_per_month"] = billable_hours
 
-overheads_df = st.data_editor(
-    st.session_state["overheads_df"],
-    num_rows="dynamic",
-    column_config={
-        "Статья расходов": st.column_config.TextColumn("Статья расходов", required=True),
-        "Сумма": st.column_config.NumberColumn(
-            f"Сумма, {currency_symbol}",
-            min_value=0.0,
-            format="%.0f",
-        ),
-        "Валюта": st.column_config.SelectboxColumn(
-            "Валюта",
-            options=["RUB", "KZT", "USD"],
-            required=True,
-        ),
-        "Период": st.column_config.SelectboxColumn(
-            "Период",
-            options=["monthly", "annual", "one-time"],
-            required=True,
-        ),
-    },
-    hide_index=True,
-    use_container_width=True,
-    key="overheads_editor",
-)
+    # --- автоматический расчёт overhead_rate ---
+    manager = ExpenseManager(billable_hours_per_month=billable_hours)
+    for item in st.session_state["firm_expenses"]:
+        try:
+            manager.add_firm_overhead(Expense.from_dict(item))
+        except ValueError as exc:
+            st.warning(f"Пропущена запись: {exc}")
 
-st.session_state["overheads_df"] = overheads_df
+    total_monthly = manager.total_overheads_monthly()
+    oh_rate = manager.calculate_overhead_rate(billable_hours)
 
-# Собираем ExpenseManager и считаем ставку накладных
-manager = ExpenseManager()
-for expense in df_to_overheads(overheads_df):
-    manager.add_firm_overhead(expense)
+    # Валюта сводки зависит от юрисдикции (для наглядности).
+    jur_choice = st.session_state.get("jurisdiction_params", {}).get("jurisdiction", "RF")
+    primary_country = jur_choice if jur_choice in CURRENCY_SYMBOLS else "RF"
+    sym = CURRENCY_SYMBOLS[primary_country]
 
-oh_total_monthly = manager.total_overheads_monthly()
-oh_rate = manager.calculate_overhead_rate(billable_hours)
+    col_m1, col_m2 = st.columns(2)
+    col_m1.metric(f"Накладные в месяц, {sym}", f"{total_monthly:,.0f}")
+    col_m2.metric(f"Overhead Rate, {sym}/ч", f"{oh_rate:,.1f}")
 
-st.session_state["expense_manager"] = manager
-st.session_state["overhead_rate"] = oh_rate
-
-col_m1, col_m2 = st.columns(2)
-col_m1.metric(f"Накладные в месяц, {currency_symbol}", f"{oh_total_monthly:,.0f}")
-col_m2.metric(f"Ставка накладных, {currency_symbol}/ч", f"{oh_rate:,.1f}")
+    # Кладём посчитанную ставку в session_state — чтобы 02_Project не пересчитывал заново.
+    st.session_state["overhead_rate"] = oh_rate

--- a/Rentab_VKR_v0.2/pages/02_Project.py
+++ b/Rentab_VKR_v0.2/pages/02_Project.py
@@ -1,39 +1,74 @@
 """
-Rentab v0.2 — страница 02: Проект и смета.
+Rentab v0.2 — страница 02: Проект и смета (итерация 3).
 
-Позволяет:
-1. Задать название проекта и добавить этапы.
-2. Назначить сотрудников на каждый этап с указанием часов.
-3. Выбрать патентные пошлины из каталога (Роспатент / Казпатент).
-4. Просмотреть итоговую смету: Blended Rate, Leverage, NNE.
+Страница собирает все параметры проекта в одной форме:
 
-Налоги считает TaxCalculator по параметрам выбранного на 01_Setup пресета.
-Накладные и пошлины — через ExpenseManager, сохранённый в session_state.
+1. Общие данные проекта (название — обязательно; клиент / описание — нет).
+2. Этапы проекта: сотрудник из состава команды + часы. Под таблицей
+   автоматически пересчитывается Blended Rate и Leverage.
+3. Необязательный блок расходов (свёрнут в expander): пошлины из каталогов
+   Роспатента / Казпатента + произвольный расход (свой с указанием категории).
+
+По кнопке «Рассчитать смету» страница:
+- собирает team_with_hours из этапов,
+- создаёт ExpenseManager из накладных фирмы + добавляет расходы проекта,
+- считает налог через TaxCalculator по jurisdiction_params,
+- сохраняет финальную структуру в st.session_state["results"] (и оставляет
+  в session_state["project_result"] ради обратной совместимости с Dashboard),
+- показывает краткий preview Gross / Tax / NNE и кнопку «Перейти к дашборду».
+
+Хардкодов нет — все параметры берутся из session_state и констант модулей.
 """
+
+from __future__ import annotations
 
 from pathlib import Path
 
 import pandas as pd
 import streamlit as st
 
-from modules.calculator import blended_rate, leverage, nne
-from modules.expenses import ExpenseManager, Expense
-from modules.jurisdiction import TaxCalculator
+from modules.calculator import (
+    blended_rate,
+    gross_revenue,
+    leverage,
+    nne,
+)
+from modules.expenses import Expense, ExpenseManager
+from modules.jurisdiction import (
+    CURRENCY_CODES,
+    CURRENCY_SYMBOLS,
+    TaxCalculator,
+)
 from modules.project import (
     ProjectStage,
-    collect_project_data,
     duties_display_options,
     load_duties_catalog,
 )
+from modules.team import total_direct_labor
 
 # ---------------------------------------------------------------------------
 # Пути к каталогам пошлин
 # ---------------------------------------------------------------------------
 DATA_DIR = Path(__file__).parent.parent / "data"
-DUTIES_CATALOGS = {
+DUTIES_CATALOGS: dict[str, Path] = {
     "RF": DATA_DIR / "rospatent_duties.json",
     "KZ": DATA_DIR / "qazpatent_duties.json",
 }
+
+# Категории «собственных» расходов проекта для произвольной строки.
+CUSTOM_EXPENSE_CATEGORIES: dict[str, str] = {
+    "disbursement_own": "Собственный расход (не перевыставляется клиенту)",
+    "disbursement_billable": "Перевыставляемый клиенту (помимо пошлин)",
+    "project_extra": "Прочее",
+}
+
+
+# ---------------------------------------------------------------------------
+# Инициализация session_state дефолтами
+# ---------------------------------------------------------------------------
+st.session_state.setdefault("project_stages", [])          # list[dict]
+st.session_state.setdefault("selected_duties", {"RF": [], "KZ": []})
+st.session_state.setdefault("custom_expenses", [])         # list[dict]
 
 # ---------------------------------------------------------------------------
 # Заголовок
@@ -41,253 +76,515 @@ DUTIES_CATALOGS = {
 st.title("📋 Проект и смета")
 
 # ---------------------------------------------------------------------------
-# Проверка: Setup заполнен
+# Предусловия: без Setup страница не считается
 # ---------------------------------------------------------------------------
-if "team" not in st.session_state or not st.session_state.get("team"):
-    st.warning("Сначала заполните состав команды на странице **01 Setup**.")
+team: list[dict] = st.session_state.get("team", [])
+if not team:
+    st.warning(
+        "Сначала заполните состав команды на странице **01 Setup → Команда**."
+    )
     st.stop()
 
-team = st.session_state["team"]
-country = st.session_state.get("country", "RF")
-currency = st.session_state.get("currency", "₽")
-regime_params = st.session_state.get(
-    "regime_params",
-    {"country": "RF", "regime": "USN", "object": "income", "vat": "none"},
-)
-overhead_rate_val = st.session_state.get("overhead_rate", 0.0)
-
-# ExpenseManager из Setup (для накладных). Если нет — создаём пустой:
-# расходы проекта добавим ниже, но накладные потеряются, что и ожидаемо.
-firm_manager: ExpenseManager = st.session_state.get("expense_manager") or ExpenseManager()
-
-# ---------------------------------------------------------------------------
-# Блок 1: Общие данные проекта
-# ---------------------------------------------------------------------------
-st.subheader("1. Общие данные")
-
-col_name, col_factor = st.columns([3, 1])
-with col_name:
-    project_name = st.text_input("Название проекта", value="IP-проект")
-with col_factor:
-    global_factor = st.number_input(
-        "Коэффициент сложности",
-        min_value=0.1,
-        max_value=5.0,
-        value=1.0,
-        step=0.1,
-        help="Умножается на все часы проекта. 1.0 = норма, 1.5 = повышенная сложность.",
+jurisdiction_params: dict | None = st.session_state.get("jurisdiction_params")
+if not jurisdiction_params:
+    st.warning(
+        "Сначала выберите юрисдикцию на странице **01 Setup → Юрисдикция и налоги**."
     )
+    st.stop()
+
+jurisdiction = jurisdiction_params.get("jurisdiction", "RF")
+
+# Основная страна для валютной разметки (символ + ISO-код).
+# В режиме «Оба» по умолчанию берём РФ; пользователь может переключить
+# в блоке расчёта ниже.
+primary_country = "KZ" if jurisdiction == "KZ" else "RF"
+currency_symbol = CURRENCY_SYMBOLS[primary_country]
+currency_code = CURRENCY_CODES[primary_country]
+
+
+# ===========================================================================
+# БЛОК 1 — ОБЩИЕ ДАННЫЕ ПРОЕКТА
+# ===========================================================================
+st.subheader("1. Данные проекта")
+
+col_name, col_client = st.columns([2, 1])
+with col_name:
+    project_name = st.text_input(
+        "Название проекта *",
+        value=st.session_state.get("project_name", ""),
+        placeholder="Регистрация товарного знака «Ромашка»",
+        key="project_name",
+    )
+with col_client:
+    project_client = st.text_input(
+        "Клиент (необязательно)",
+        value=st.session_state.get("project_client", ""),
+        placeholder="ООО «Ромашка»",
+        key="project_client",
+    )
+
+project_description = st.text_area(
+    "Краткое описание (необязательно)",
+    value=st.session_state.get("project_description", ""),
+    placeholder="Классы МКТУ 05, 29, 30; приоритет по Парижской конвенции…",
+    height=80,
+    key="project_description",
+)
 
 st.markdown("---")
 
-# ---------------------------------------------------------------------------
-# Блок 2: Этапы проекта
-# ---------------------------------------------------------------------------
+
+# ===========================================================================
+# БЛОК 2 — ЭТАПЫ ПРОЕКТА
+# ===========================================================================
 st.subheader("2. Этапы проекта")
 
-if "stage_names" not in st.session_state:
-    st.session_state["stage_names"] = ["Анализ документов", "Подготовка заявки", "Сопровождение"]
+team_names: list[str] = [m["name"] for m in team]
 
-col_add, col_clear = st.columns([2, 1])
-with col_add:
-    new_stage = st.text_input("Добавить этап", placeholder="Название нового этапа")
-with col_clear:
-    st.markdown("<br>", unsafe_allow_html=True)
-    if st.button("Добавить") and new_stage:
-        if new_stage not in st.session_state["stage_names"]:
-            st.session_state["stage_names"].append(new_stage)
-
-stages_to_remove = st.multiselect(
-    "Удалить этапы",
-    options=st.session_state["stage_names"],
-    default=[],
-)
-if stages_to_remove:
-    st.session_state["stage_names"] = [
-        s for s in st.session_state["stage_names"] if s not in stages_to_remove
-    ]
-
-st.markdown("---")
-
-# ---------------------------------------------------------------------------
-# Блок 3: Назначение исполнителей
-# ---------------------------------------------------------------------------
-st.subheader("3. Назначение исполнителей по этапам")
-st.caption("Укажите количество часов для каждого сотрудника на каждом этапе.")
-
-stages: list[ProjectStage] = []
-
-for stage_name in st.session_state["stage_names"]:
-    with st.expander(f"Этап: {stage_name}", expanded=True):
-        hours_data: dict[str, float] = {}
-        cols = st.columns(len(team))
-        for col, member in zip(cols, team):
-            with col:
-                h = st.number_input(
-                    f"{member['name']} ({member['role']})",
-                    min_value=0.0,
-                    value=0.0,
-                    step=1.0,
-                    key=f"hours_{stage_name}_{member['name']}",
-                )
-                hours_data[member["name"]] = h
-
-        assigned = [
-            {**member, "hours": hours_data.get(member["name"], 0.0)}
-            for member in team
-            if hours_data.get(member["name"], 0.0) > 0
-        ]
-
-        stage = ProjectStage(
-            name=stage_name,
-            assigned_members=assigned,
-            complexity_factor=global_factor,
+with st.form("add_stage_form", clear_on_submit=True):
+    col_sname, col_exec, col_hours = st.columns([2, 1.5, 1])
+    with col_sname:
+        stage_name_input = st.text_input(
+            "Название этапа",
+            placeholder="Поиск по базам / Подача заявки / Ответ на уведомление",
         )
-        stages.append(stage)
-
-st.markdown("---")
-
-# ---------------------------------------------------------------------------
-# Блок 4: Патентные пошлины
-# ---------------------------------------------------------------------------
-st.subheader("4. Патентные пошлины")
-
-duties_path = DUTIES_CATALOGS.get(country)
-selected_duties_amounts: list[float] = []
-selected_labels: list[str] = []
-
-if duties_path and duties_path.exists():
-    duties_list = load_duties_catalog(duties_path)
-    options = duties_display_options(duties_list)
-
-    selected_labels = st.multiselect(
-        f"Выберите пошлины ({currency})",
-        options=list(options.keys()),
-    )
-    selected_duties_amounts = [options[lbl] for lbl in selected_labels]
-
-    if selected_duties_amounts:
-        st.info(
-            f"Сумма пошлин: **{sum(selected_duties_amounts):,.0f} {currency}** "
-            "(агентская схема — вне налоговой базы)"
+    with col_exec:
+        stage_executor = st.selectbox(
+            "Исполнитель",
+            options=team_names,
+            help="Выбирается из состава команды, заданного на странице Setup.",
         )
+    with col_hours:
+        stage_hours = st.number_input(
+            "Часы",
+            min_value=0.0,
+            value=0.0,
+            step=1.0,
+            format="%.1f",
+        )
+
+    added = st.form_submit_button("➕ Добавить этап")
+    if added:
+        if not stage_name_input.strip():
+            st.error("Название этапа не может быть пустым.")
+        elif stage_hours <= 0:
+            st.error("Часы должны быть больше нуля.")
+        else:
+            st.session_state["project_stages"].append(
+                {
+                    "name": stage_name_input.strip(),
+                    "executor": stage_executor,
+                    "hours": float(stage_hours),
+                }
+            )
+            st.success(f"Добавлен этап: {stage_name_input}")
+
+# --- отображение списка этапов ---
+stages_data: list[dict] = st.session_state["project_stages"]
+
+if not stages_data:
+    st.info("Пока нет этапов. Добавьте первый этап через форму выше.")
 else:
-    st.caption("Каталог пошлин для выбранной юрисдикции не найден.")
+    # Собираем team-lookup по имени для подстановки ставок.
+    team_by_name: dict[str, dict] = {m["name"]: m for m in team}
+
+    st.markdown("#### Состав этапов")
+    for idx, stage in enumerate(list(stages_data)):
+        executor = stage["executor"]
+        member = team_by_name.get(executor)
+        if member is None:
+            # Исполнитель удалён из команды на Setup — предупреждаем и пропускаем.
+            st.warning(
+                f"Исполнитель «{executor}» этапа «{stage['name']}» отсутствует "
+                f"в текущем составе команды. Удалите этап или измените состав."
+            )
+            continue
+
+        c1, c2, c3, c4, c5 = st.columns([2, 1.5, 0.8, 1.2, 0.5])
+        c1.write(f"**{stage['name']}**")
+        c2.write(f"{executor} ({member['role']})")
+        c3.write(f"{stage['hours']:.1f} ч")
+        c4.write(f"{member['billing_rate'] * stage['hours']:,.0f} {currency_symbol}")
+        if c5.button("🗑", key=f"del_stage_{idx}", help="Удалить этап"):
+            st.session_state["project_stages"].pop(idx)
+            st.rerun()
+
+    st.caption(
+        "Колонки: Этап · Исполнитель · Часы · Выручка по этапу "
+        f"({currency_symbol} = billing × hours)"
+    )
+
+# --- реактивный пересчёт Blended Rate и Leverage ---
+# Собираем team_with_hours одним проходом: каждой строке этапа соответствует
+# член команды с «унаследованными» billing_rate/cost_rate/role.
+team_with_hours: list[dict] = []
+for stage in stages_data:
+    member = next((m for m in team if m["name"] == stage["executor"]), None)
+    if member is None:
+        continue
+    team_with_hours.append(
+        {
+            "name": member["name"],
+            "role": member["role"],
+            "billing_rate": float(member["billing_rate"]),
+            "cost_rate": float(member["cost_rate"]),
+            "hours": float(stage["hours"]),
+        }
+    )
+
+br_current = blended_rate(team_with_hours)
+lev_current = leverage(team_with_hours)
+hours_total = sum(m["hours"] for m in team_with_hours)
+
+col_m1, col_m2, col_m3 = st.columns(3)
+col_m1.metric(f"Blended Rate, {currency_symbol}/ч", f"{br_current:,.0f}")
+col_m2.metric(
+    "Leverage",
+    f"{lev_current:.2f}",
+    help="Часы младших / часы старших. Выше — выше маржа.",
+)
+col_m3.metric("Всего часов", f"{hours_total:.1f}")
 
 st.markdown("---")
 
-# ---------------------------------------------------------------------------
-# Расчёты
-# ---------------------------------------------------------------------------
-project_data = collect_project_data(stages, selected_duties_amounts)
-team_hours = project_data["team_with_hours"]
 
-if not team_hours:
-    st.info("Назначьте часы сотрудникам для просмотра расчётов.")
-    st.stop()
-
-gr = project_data["gross_revenue"]
-direct_labor = project_data["direct_labor"]
-total_hours = project_data["total_hours"]
-disbursements = project_data["disbursements_billed"]
-
-# Обновляем расходы проекта в менеджере (пошлины = billable disbursements)
-firm_manager.clear_project_expenses()
-currency_code = st.session_state.get("currency_code", "RUB")
-for label, amount in zip(selected_labels, selected_duties_amounts):
-    firm_manager.add_project_expense(
-        Expense(
-            name=label,
-            category="disbursement_billable",
-            amount=float(amount),
-            currency=currency_code,
-            period="one-time",
-            billable=True,
-        )
+# ===========================================================================
+# БЛОК 3 — РАСХОДЫ ПРОЕКТА (НЕОБЯЗАТЕЛЬНО)
+# ===========================================================================
+with st.expander("3. Расходы проекта — пошлины, субподряд и др. (необязательно)"):
+    # --- 3.1. Пошлины из каталога(ов) ---
+    st.markdown("#### Пошлины из каталога")
+    st.caption(
+        "Пошлины — агентские транзитные расходы: перевыставляются клиенту "
+        "без наценки и исключаются из налоговой базы."
     )
 
-br = blended_rate(team_hours)
-lev = leverage(team_hours)
-oh_alloc = overhead_rate_val * total_hours
+    # В режиме «Оба» показываем оба каталога, иначе — только актуальный.
+    active_countries: list[str] = (
+        ["RF", "KZ"] if jurisdiction == "Both" else [jurisdiction]
+    )
 
-# Налог через TaxCalculator с учётом агентских пошлин и прямых расходов
-tax_calc = TaxCalculator(regime_params)
-tax_result = tax_calc.calculate_tax(
-    revenue=gr + disbursements,
-    params={
-        **regime_params,
-        "expenses": direct_labor + oh_alloc,
-        "disbursements_billed": disbursements,
-    },
+    for country_code in active_countries:
+        catalog_path = DUTIES_CATALOGS.get(country_code)
+        if catalog_path is None or not catalog_path.exists():
+            st.caption(
+                f"Каталог пошлин для {country_code} не найден "
+                f"({catalog_path}) — пропускаем."
+            )
+            continue
+
+        duties_list = load_duties_catalog(catalog_path)
+        duties_map = duties_display_options(duties_list)  # {action: amount}
+        sym = CURRENCY_SYMBOLS[country_code]
+
+        st.markdown(
+            f"**{'🇷🇺 Роспатент' if country_code == 'RF' else '🇰🇿 Казпатент'} "
+            f"({sym})**"
+        )
+
+        selected_labels = st.multiselect(
+            f"Выберите пошлины ({country_code})",
+            options=list(duties_map.keys()),
+            default=st.session_state["selected_duties"].get(country_code, []),
+            key=f"duties_multiselect_{country_code}",
+        )
+        st.session_state["selected_duties"][country_code] = selected_labels
+
+        if selected_labels:
+            subtotal = sum(duties_map[lbl] for lbl in selected_labels)
+            st.info(f"Сумма: **{subtotal:,.0f} {sym}**")
+
+    st.markdown("---")
+
+    # --- 3.2. Произвольный расход ---
+    st.markdown("#### Произвольный расход")
+    st.caption(
+        "Например: командировка юриста (собственный расход), "
+        "нотариус для клиента (перевыставляемый), перевод документов."
+    )
+
+    with st.form("add_custom_expense_form", clear_on_submit=True):
+        col_cn, col_cc = st.columns([2, 1])
+        with col_cn:
+            ce_name = st.text_input(
+                "Название", placeholder="Командировка в Роспатент"
+            )
+        with col_cc:
+            ce_category = st.selectbox(
+                "Категория",
+                options=list(CUSTOM_EXPENSE_CATEGORIES.keys()),
+                format_func=lambda k: CUSTOM_EXPENSE_CATEGORIES[k],
+            )
+
+        col_ca, col_cu = st.columns([1, 1])
+        with col_ca:
+            ce_amount = st.number_input(
+                "Сумма", min_value=0.0, value=0.0, step=500.0, format="%.0f"
+            )
+        with col_cu:
+            ce_currency = st.selectbox(
+                "Валюта", options=list(CURRENCY_CODES.values()) + ["USD"]
+            )
+
+        ce_submit = st.form_submit_button("➕ Добавить расход")
+        if ce_submit:
+            if not ce_name.strip():
+                st.error("Название расхода не может быть пустым.")
+            elif ce_amount <= 0:
+                st.error("Сумма должна быть больше нуля.")
+            else:
+                st.session_state["custom_expenses"].append(
+                    {
+                        "name": ce_name.strip(),
+                        "category": ce_category,
+                        "amount": float(ce_amount),
+                        "currency": ce_currency,
+                        "period": "one-time",
+                        "billable": ce_category == "disbursement_billable",
+                    }
+                )
+                st.success(f"Добавлен расход: {ce_name}")
+
+    # Список текущих произвольных расходов.
+    custom_list: list[dict] = st.session_state["custom_expenses"]
+    if custom_list:
+        st.markdown("**Текущие произвольные расходы**")
+        for idx, exp in enumerate(list(custom_list)):
+            c1, c2, c3, c4 = st.columns([2, 2, 1, 0.5])
+            c1.write(f"**{exp['name']}**")
+            c2.write(CUSTOM_EXPENSE_CATEGORIES.get(exp["category"], exp["category"]))
+            c3.write(f"{exp['amount']:,.0f} {exp['currency']}")
+            if c4.button("🗑", key=f"del_custom_{idx}", help="Удалить"):
+                st.session_state["custom_expenses"].pop(idx)
+                st.rerun()
+
+st.markdown("---")
+
+
+# ===========================================================================
+# БЛОК 4 — ВЫБОР ЮРИСДИКЦИИ ДЛЯ РАСЧЁТА (в режиме «Оба»)
+# ===========================================================================
+# В режиме «Оба» TaxCalculator должен работать с одним набором параметров.
+# Даём пользователю выбрать, какую юрисдикцию применить к смете.
+if jurisdiction == "Both":
+    st.subheader("4. Выбор юрисдикции для сметы")
+    calc_country = st.radio(
+        "В какой юрисдикции рассчитать налог этого проекта?",
+        options=["RF", "KZ"],
+        format_func=lambda c: "🇷🇺 Россия" if c == "RF" else "🇰🇿 Казахстан",
+        horizontal=True,
+        key="calc_country_choice",
+    )
+else:
+    calc_country = jurisdiction
+
+# Выбираем params и валюту для расчёта.
+if calc_country == "RF":
+    tax_params = jurisdiction_params.get("rf") or {
+        "country": "RF",
+        "regime": "USN",
+        "object": "income",
+        "vat": "none",
+    }
+else:
+    tax_params = jurisdiction_params.get("kz") or {
+        "country": "KZ",
+        "regime": "OUR",
+        "form": "too",
+        "vat": "none",
+    }
+
+calc_symbol = CURRENCY_SYMBOLS[calc_country]
+calc_code = CURRENCY_CODES[calc_country]
+
+
+# ===========================================================================
+# БЛОК 5 — КНОПКА «РАССЧИТАТЬ СМЕТУ»
+# ===========================================================================
+st.subheader("5. Рассчитать смету")
+
+calc_disabled = not (project_name.strip() and team_with_hours)
+if calc_disabled:
+    st.caption(
+        "Чтобы рассчитать смету, укажите название проекта и добавьте "
+        "хотя бы один этап с часами."
+    )
+
+calc_clicked = st.button(
+    "💰 Рассчитать смету",
+    type="primary",
+    disabled=calc_disabled,
 )
-tax = tax_result["total_tax"]
-disbursements_own = firm_manager.get_disbursements_own()
 
-nne_val = nne(gr, direct_labor, oh_alloc, disbursements_own, tax)
-total_client = gr + disbursements
+if calc_clicked:
+    # --- 1. Менеджер расходов: накладные фирмы + расходы проекта ---
+    billable_hours_month = float(
+        st.session_state.get("billable_hours_per_month", 160.0)
+    )
+    manager = ExpenseManager(billable_hours_per_month=billable_hours_month)
 
-# ---------------------------------------------------------------------------
-# Вывод сметы
-# ---------------------------------------------------------------------------
-st.subheader("5. Смета проекта")
+    # Накладные фирмы из Setup.
+    for item in st.session_state.get("firm_expenses", []):
+        try:
+            manager.add_firm_overhead(Expense.from_dict(item))
+        except ValueError as exc:
+            st.warning(f"Пропущен накладной расход: {exc}")
 
-col1, col2, col3, col4 = st.columns(4)
-col1.metric(f"Итого для клиента, {currency}", f"{total_client:,.0f}")
-col2.metric(f"Blended Rate, {currency}/ч", f"{br:,.0f}")
-col3.metric("Leverage", f"{lev:.2f}")
-col4.metric(
-    f"NNE, {currency}",
-    f"{nne_val:,.0f}",
-    delta=f"{(nne_val / gr * 100):.1f}% маржа" if gr else None,
-)
+    # Пошлины — только из активных каталогов для выбранной юрисдикции.
+    # (В режиме «Оба» берём обе страны: фирма всё равно их оплачивает.)
+    disb_countries = (
+        ["RF", "KZ"] if jurisdiction == "Both" else [jurisdiction]
+    )
+    for cc in disb_countries:
+        catalog_path = DUTIES_CATALOGS.get(cc)
+        if catalog_path is None or not catalog_path.exists():
+            continue
+        duties_list = load_duties_catalog(catalog_path)
+        duties_map = duties_display_options(duties_list)
+        for label in st.session_state["selected_duties"].get(cc, []):
+            amount = float(duties_map.get(label, 0.0))
+            if amount <= 0:
+                continue
+            manager.add_project_expense(
+                Expense(
+                    name=label,
+                    category="disbursement_billable",
+                    amount=amount,
+                    currency=CURRENCY_CODES[cc],
+                    period="one-time",
+                    billable=True,
+                )
+            )
 
-with st.expander("Детальный расчёт"):
-    st.markdown(f"""
-    **Режим:** {tax_result['regime_label']}
+    # Произвольные расходы проекта.
+    for item in st.session_state.get("custom_expenses", []):
+        try:
+            manager.add_project_expense(Expense.from_dict(item))
+        except ValueError as exc:
+            st.warning(f"Пропущен произвольный расход: {exc}")
 
-    **Выручка за услуги:** {gr:,.0f} {currency}
-    **Пошлины (транзит):** {disbursements:,.0f} {currency}
-    **Итого для клиента:** {total_client:,.0f} {currency}
+    # --- 2. Финансовые показатели ---
+    gr_val = gross_revenue(team_with_hours)
+    direct_labor_val = total_direct_labor(team_with_hours)
+    total_hours_val = sum(m["hours"] for m in team_with_hours)
 
-    ---
-    **Прямые трудозатраты (Direct Labor):** {direct_labor:,.0f} {currency}
-    **Накладные (Overheads alloc.):** {oh_alloc:,.0f} {currency}
-    **Налогооблагаемая база:** {tax_result['taxable_base']:,.0f} {currency}
-    **Налог на доход:** {tax_result['income_tax']:,.0f} {currency}
-    **НДС:** {tax_result['vat']:,.0f} {currency}
-    **Итого налог:** {tax:,.0f} {currency}
+    # Накладные аллоцируем пропорционально часам проекта:
+    #     overhead_rate = monthly_overheads / billable_hours_per_month    [валюта/час]
+    #     overheads_alloc = overhead_rate × total_hours_project            [валюта]
+    # Это классическая PSF-аллокация по фактически отработанным часам —
+    # размерности сходятся, в отличие от аллокации по сумме трудозатрат.
+    overheads_alloc = manager.get_overheads_allocated(total_hours_val)
 
-    ---
-    **NNE = {gr:,.0f} − {direct_labor:,.0f} − {oh_alloc:,.0f} − {disbursements_own:,.0f} − {tax:,.0f} = {nne_val:,.0f} {currency}**
-    """)
+    disbursements_billed = manager.get_disbursements_billed()
+    disbursements_own = manager.get_disbursements_own()
 
-    rows = []
-    for m in team_hours:
-        rows.append({
-            "Сотрудник": m["name"],
-            "Роль": m["role"],
-            "Часы": m["hours"],
-            f"Billing, {currency}": m["billing_rate"] * m["hours"],
-            f"Cost, {currency}": m["cost_rate"] * m["hours"],
-        })
-    st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
+    # --- 3. Налог через TaxCalculator ---
+    tax_calc = TaxCalculator(tax_params)
+    tax_result = tax_calc.calculate_tax(
+        revenue=gr_val + disbursements_billed,
+        params={
+            **tax_params,
+            "expenses": direct_labor_val + overheads_alloc + disbursements_own,
+            "disbursements_billed": disbursements_billed,
+        },
+    )
+    tax_total = float(tax_result["total_tax"])
 
-# Передаём данные на Dashboard
-st.session_state["project_result"] = {
-    "project_name": project_name,
-    "gross_revenue": gr,
-    "direct_labor": direct_labor,
-    "overheads_alloc": oh_alloc,
-    "disbursements": disbursements,
-    "disbursements_own": disbursements_own,
-    "tax": tax,
-    "income_tax": tax_result["income_tax"],
-    "vat": tax_result["vat"],
-    "regime_label": tax_result["regime_label"],
-    "nne": nne_val,
-    "blended_rate": br,
-    "leverage": lev,
-    "total_hours": total_hours,
-    "total_client": total_client,
-    "currency": currency,
-}
+    # --- 4. NNE ---
+    nne_val = nne(
+        gross=gr_val,
+        direct_labor=direct_labor_val,
+        overheads_alloc=overheads_alloc,
+        disbursements_own=disbursements_own,
+        tax=tax_total,
+    )
+
+    # --- 5. Сохраняем результат ---
+    results = {
+        # идентификация проекта
+        "project_name": project_name,
+        "client": project_client,
+        "description": project_description,
+        # юрисдикция
+        "calc_country": calc_country,
+        "jurisdiction_mode": jurisdiction,
+        "currency": calc_symbol,
+        "currency_code": calc_code,
+        "regime_label": tax_result["regime_label"],
+        # показатели команды
+        "blended_rate": br_current,
+        "leverage": lev_current,
+        "total_hours": total_hours_val,
+        # финансы
+        "gross_revenue": gr_val,
+        "direct_labor": direct_labor_val,
+        "overheads_alloc": overheads_alloc,
+        "disbursements": disbursements_billed,
+        "disbursements_own": disbursements_own,
+        "income_tax": float(tax_result["income_tax"]),
+        "vat": float(tax_result["vat"]),
+        "tax": tax_total,
+        "taxable_base": float(tax_result["taxable_base"]),
+        "nne": nne_val,
+        "total_client": gr_val + disbursements_billed,
+        # детализация команды для таблицы
+        "team_with_hours": team_with_hours,
+    }
+    st.session_state["results"] = results
+    # Обратная совместимость: старый ключ также обновляем,
+    # чтобы 03_Dashboard работал без изменений на старых сессиях.
+    st.session_state["project_result"] = results
+
+
+# ===========================================================================
+# БЛОК 6 — PREVIEW РАСЧЁТА
+# ===========================================================================
+results_current: dict | None = st.session_state.get("results")
+if results_current:
+    st.markdown("### Предварительный результат")
+
+    sym = results_current["currency"]
+    p1, p2, p3 = st.columns(3)
+    p1.metric(f"Gross Revenue, {sym}", f"{results_current['gross_revenue']:,.0f}")
+    p2.metric(f"Tax, {sym}", f"{results_current['tax']:,.0f}")
+    p3.metric(
+        f"NNE, {sym}",
+        f"{results_current['nne']:,.0f}",
+        delta=(
+            f"{(results_current['nne'] / results_current['gross_revenue'] * 100):.1f}%"
+            if results_current["gross_revenue"]
+            else None
+        ),
+    )
+
+    st.caption(
+        f"Режим: {results_current['regime_label']} · "
+        f"Пошлины (транзит): {results_current['disbursements']:,.0f} {sym} · "
+        f"Собственные расходы: {results_current['disbursements_own']:,.0f} {sym}"
+    )
+
+    # Кнопка-подсказка. Сам переход возможен через sidebar Streamlit,
+    # поэтому кнопка здесь — навигационная подсказка.
+    st.page_link(
+        "pages/03_Dashboard.py",
+        label="📊 Перейти к дашборду",
+        icon="➡️",
+    )
+
+    with st.expander("Детали расчёта"):
+        rows = []
+        for m in results_current["team_with_hours"]:
+            rows.append(
+                {
+                    "Сотрудник": m["name"],
+                    "Роль": m["role"],
+                    "Часы": m["hours"],
+                    f"Billing, {sym}": m["billing_rate"] * m["hours"],
+                    f"Cost, {sym}": m["cost_rate"] * m["hours"],
+                }
+            )
+        st.dataframe(
+            pd.DataFrame(rows),
+            use_container_width=True,
+            hide_index=True,
+        )

--- a/Rentab_VKR_v0.2/pages/03_Dashboard.py
+++ b/Rentab_VKR_v0.2/pages/03_Dashboard.py
@@ -22,11 +22,13 @@ st.title("📊 Dashboard")
 # ---------------------------------------------------------------------------
 # Проверяем наличие расчётных данных
 # ---------------------------------------------------------------------------
-if "project_result" not in st.session_state:
+# Итерация 3: основной ключ — "results". На старых сессиях (до переименования)
+# данные могут лежать в "project_result" — fallback сохраняем для совместимости.
+r: dict | None = st.session_state.get("results") or st.session_state.get("project_result")
+if r is None:
     st.warning("Сформируйте смету на странице **02 Project** для отображения Dashboard.")
     st.stop()
 
-r = st.session_state["project_result"]
 currency = r["currency"]
 overhead_rate_val = st.session_state.get("overhead_rate", 0.0)
 


### PR DESCRIPTION
Фиксы по ревью итерации 2:
- ExpenseManager: billable_hours_per_month как атрибут, прямая формула get_overheads_allocated = overhead_rate × hours.
- Expense.from_dict: все поля через data.get(..., default) — устойчивость к неполным JSON-записям.
- TaxCalculator.add_payroll_taxes теперь поддерживает РФ: НДФЛ 13%/15% c порогом 5 млн + страховые взносы 30% / 0% (АУСН).
- Роли EmployeeRole переведены на русский (Партнёр / Старший юрист / …); calculator.leverage читает SENIOR_ROLES/JUNIOR_ROLES из modules.team вместо хардкода английских строк.

Итерация 3 — переработка страниц:
- 01_Setup.py разбит на 3 вкладки (юрисдикция / команда / накладные). Параметры юрисдикции сохраняются в единый session_state["jurisdiction_params"] со структурой {jurisdiction, rf, kz, exchange_rate_rub_per_kzt}.
- 02_Project.py: форма (данные проекта → этапы → опциональный блок расходов в expander), реактивный пересчёт Blended Rate / Leverage, кнопка «Рассчитать смету» с preview Gross / Tax / NNE и ссылкой на Dashboard.
- 03_Dashboard.py читает session_state["results"] (fallback — старый project_result для обратной совместимости).