### PR TITLE
feat(Rentab v0.2): Итерация 4 — дашборд, АУСН, русификация

### DIFF
--- a/Rentab_VKR_v0.2/modules/expenses.py
+++ b/Rentab_VKR_v0.2/modules/expenses.py
@@ -234,7 +234,9 @@ class ExpenseManager:
         """
         if direct_costs <= 0:
             return 0.0
-        overhead_rate = self.total_overheads_monthly() / self.billable_hours_per_month
+        # Переиспользуем calculate_overhead_rate — единый источник правды для ставки
+        # (DRY + защита от ZeroDivisionError внутри самого метода).
+        overhead_rate = self.calculate_overhead_rate(self.billable_hours_per_month)
         return overhead_rate * direct_costs
 
     # -- расходы проекта ----------------------------------------------------

--- a/Rentab_VKR_v0.2/modules/jurisdiction.py
+++ b/Rentab_VKR_v0.2/modules/jurisdiction.py
@@ -62,6 +62,17 @@ TAX_RATES_RF_2026: dict[str, Any] = {
         "high_rate": 0.15,
         "threshold": 5_000_000,   # руб./год
     },
+    # АУСН — Автоматизированная УСН (с 2022 г., пилотный режим).
+    # Фиксированная ставка 8% с дохода; НДС не применяется;
+    # страховые взносы 0% (работодатель не платит, бюджет компенсирует).
+    # Ограничения: доход до 60 млн ₽/год, штат до 5 чел.
+    "AUSN": {
+        "country": "RF",
+        "income_tax_rate": 0.08,
+        "vat": None,
+        "insurance_contributions": 0.0,
+        "label": "АУСН — Автоматизированная УСН (8%, без страховых взносов)",
+    },
 }
 
 
@@ -503,6 +514,17 @@ class TaxCalculator:
             vat = taxable_base * vat_rate
 
             label = f"ОСНО (прибыль {income_rate * 100:.0f}% + НДС {vat_rate * 100:.0f}%)"
+
+        elif regime == "AUSN":
+            # АУСН: плоские 8% от дохода, НДС и взносы не применяются.
+            # Налоговая база — как у «УСН Доходы», просто ставка выше.
+            ausn = rates["AUSN"]
+            income_rate = float(ausn["income_tax_rate"])
+            income_tax_base = taxable_base
+            income_tax = taxable_base * income_rate
+            vat_rate = 0.0
+            vat = 0.0
+            label = ausn["label"]
 
         elif regime == "NPD":
             client_type = p.get("client_type", "legal_entity")

--- a/Rentab_VKR_v0.2/pages/01_Setup.py
+++ b/Rentab_VKR_v0.2/pages/01_Setup.py
@@ -48,9 +48,10 @@ JURISDICTION_OPTIONS: dict[str, str] = {
 
 # Список режимов РФ (ключи) — для st.radio. Человекочитаемые подписи
 # собираем из TAX_RATES_RF_2026 динамически, без дублирования.
-RF_REGIME_KEYS: list[str] = ["USN", "OSNO", "NPD"]
+RF_REGIME_KEYS: list[str] = ["USN", "AUSN", "OSNO", "NPD"]
 RF_REGIME_LABELS: dict[str, str] = {
     "USN": "УСН",
+    "AUSN": "АУСН",
     "OSNO": "ОСНО",
     "NPD": "НПД (самозанятость)",
 }
@@ -135,6 +136,17 @@ with tab_jur:
                 vat=usn_vat,
                 social_contributions=usn_sc,
             )
+
+        elif rf_regime == "AUSN":
+            st.info(
+                "АУСН: налог 8% с дохода, страховые взносы 0%, НДС не применяется. "
+                "Доступен для компаний с доходом до 60 млн ₽/год и штатом до 5 чел.",
+                icon="ℹ️",
+            )
+            # Режим фиксированный — никаких дополнительных выборов.
+            # Для расчёта payroll автоматически выставляем нулевые взносы,
+            # чтобы add_payroll_taxes вернул 0 ₽ страховых отчислений.
+            rf_params["social_contributions"] = "zero"
 
         elif rf_regime == "OSNO":
             st.info(
@@ -241,7 +253,7 @@ with tab_team:
         col_bill, col_cost = st.columns(2)
         with col_bill:
             new_billing = st.number_input(
-                "Billing rate (ставка для клиента)",
+                "Ставка для клиента (₽ или ₸ / ч)",
                 min_value=0.0,
                 value=0.0,
                 step=500.0,
@@ -249,7 +261,7 @@ with tab_team:
             )
         with col_cost:
             new_cost = st.number_input(
-                "Cost rate (себестоимость часа)",
+                "Себестоимость часа (ФОТ + отчисления)",
                 min_value=0.0,
                 value=0.0,
                 step=500.0,
@@ -289,7 +301,7 @@ with tab_team:
 
         st.caption(
             f"Всего: {len(team_list)} сотрудников · "
-            "столбцы: Имя · Роль · Billing · Cost"
+            "столбцы: Имя · Роль · Ставка · Себестоимость"
         )
 
 
@@ -400,7 +412,7 @@ with tab_exp:
 
     col_m1, col_m2 = st.columns(2)
     col_m1.metric(f"Накладные в месяц, {sym}", f"{total_monthly:,.0f}")
-    col_m2.metric(f"Overhead Rate, {sym}/ч", f"{oh_rate:,.1f}")
+    col_m2.metric(f"Ставка накладных, {sym}/ч", f"{oh_rate:,.1f}")
 
     # Кладём посчитанную ставку в session_state — чтобы 02_Project не пересчитывал заново.
     st.session_state["overhead_rate"] = oh_rate

--- a/Rentab_VKR_v0.2/pages/02_Project.py
+++ b/Rentab_VKR_v0.2/pages/02_Project.py
@@ -182,12 +182,13 @@ with st.form("add_stage_form", clear_on_submit=True):
 # --- отображение списка этапов ---
 stages_data: list[dict] = st.session_state["project_stages"]
 
+# Словарь-lookup по имени — используется и в отрисовке списка, и в сборке
+# team_with_hours ниже по странице.
+team_by_name: dict[str, dict] = {m["name"]: m for m in team}
+
 if not stages_data:
     st.info("Пока нет этапов. Добавьте первый этап через форму выше.")
 else:
-    # Собираем team-lookup по имени для подстановки ставок.
-    team_by_name: dict[str, dict] = {m["name"]: m for m in team}
-
     st.markdown("#### Состав этапов")
     for idx, stage in enumerate(list(stages_data)):
         executor = stage["executor"]
@@ -216,14 +217,16 @@ else:
 
 # --- реактивный пересчёт Blended Rate и Leverage ---
 # Собираем team_with_hours одним проходом: каждой строке этапа соответствует
-# член команды с «унаследованными» billing_rate/cost_rate/role.
+# член команды с «унаследованными» billing_rate/cost_rate/role. Имя этапа
+# пробрасываем дальше, чтобы дашборд мог построить детальную таблицу по этапам.
 team_with_hours: list[dict] = []
 for stage in stages_data:
-    member = next((m for m in team if m["name"] == stage["executor"]), None)
+    member = team_by_name.get(stage["executor"])
     if member is None:
         continue
     team_with_hours.append(
         {
+            "stage_name": stage["name"],
             "name": member["name"],
             "role": member["role"],
             "billing_rate": float(member["billing_rate"]),
@@ -237,9 +240,9 @@ lev_current = leverage(team_with_hours)
 hours_total = sum(m["hours"] for m in team_with_hours)
 
 col_m1, col_m2, col_m3 = st.columns(3)
-col_m1.metric(f"Blended Rate, {currency_symbol}/ч", f"{br_current:,.0f}")
+col_m1.metric(f"Средневзвешенная ставка, {currency_symbol}/ч", f"{br_current:,.0f}")
 col_m2.metric(
-    "Leverage",
+    "Коэффициент рычага",
     f"{lev_current:.2f}",
     help="Часы младших / часы старших. Выше — выше маржа.",
 )
@@ -500,6 +503,12 @@ if calc_clicked:
     )
 
     # --- 5. Сохраняем результат ---
+    # В results.project_expenses складываем все расходы проекта (пошлины +
+    # произвольные) в сериализованном виде — чтобы дашборд мог построить
+    # табличку «Расходы проекта» без повторного обхода session_state.
+    project_expenses_dump = [e.to_dict() for e in manager.project_expenses]
+    overhead_rate_val = manager.calculate_overhead_rate(billable_hours_month)
+
     results = {
         # идентификация проекта
         "project_name": project_name,
@@ -515,6 +524,7 @@ if calc_clicked:
         "blended_rate": br_current,
         "leverage": lev_current,
         "total_hours": total_hours_val,
+        "overhead_rate": overhead_rate_val,
         # финансы
         "gross_revenue": gr_val,
         "direct_labor": direct_labor_val,
@@ -527,8 +537,9 @@ if calc_clicked:
         "taxable_base": float(tax_result["taxable_base"]),
         "nne": nne_val,
         "total_client": gr_val + disbursements_billed,
-        # детализация команды для таблицы
+        # детализация для дашборда
         "team_with_hours": team_with_hours,
+        "project_expenses": project_expenses_dump,
     }
     st.session_state["results"] = results
     # Обратная совместимость: старый ключ также обновляем,
@@ -545,10 +556,10 @@ if results_current:
 
     sym = results_current["currency"]
     p1, p2, p3 = st.columns(3)
-    p1.metric(f"Gross Revenue, {sym}", f"{results_current['gross_revenue']:,.0f}")
-    p2.metric(f"Tax, {sym}", f"{results_current['tax']:,.0f}")
+    p1.metric(f"Выручка, {sym}", f"{results_current['gross_revenue']:,.0f}")
+    p2.metric(f"Налог, {sym}", f"{results_current['tax']:,.0f}")
     p3.metric(
-        f"NNE, {sym}",
+        f"Чистая прибыль (NNE), {sym}",
         f"{results_current['nne']:,.0f}",
         delta=(
             f"{(results_current['nne'] / results_current['gross_revenue'] * 100):.1f}%"
@@ -579,8 +590,8 @@ if results_current:
                     "Сотрудник": m["name"],
                     "Роль": m["role"],
                     "Часы": m["hours"],
-                    f"Billing, {sym}": m["billing_rate"] * m["hours"],
-                    f"Cost, {sym}": m["cost_rate"] * m["hours"],
+                    f"Выручка, {sym}": m["billing_rate"] * m["hours"],
+                    f"Себестоимость, {sym}": m["cost_rate"] * m["hours"],
                 }
             )
         st.dataframe(

--- a/Rentab_VKR_v0.2/pages/03_Dashboard.py
+++ b/Rentab_VKR_v0.2/pages/03_Dashboard.py
@@ -1,166 +1,374 @@
 """
-Rentab v0.2 — страница 03: Dashboard.
+Rentab v0.2 — страница 03: Дашборд (итерация 4).
 
-Отображает итоговые KPI проекта и структуру цены в виде диаграммы.
+Страница рассчитана на показ уже сформированной на «Проекте» сметы
+(st.session_state["results"]) и состоит из пяти блоков:
 
-Визуализация:
-- Plotly Pie Chart: доли Labor / Overheads / Disbursements / Tax / NNE
-- st.metric: Blended Rate, Leverage, NNE, Overhead Rate
+1. Карточки верхнего уровня — выручка, перевыставляемые расходы (если есть),
+   итоговый счёт клиенту, чистая прибыль (NNE) с маржой.
+2. Структура цены (plotly pie) + вспомогательные метрики справа.
+3. Таблица по этапам с итоговой строкой.
+4. Таблица расходов проекта (показывается только если есть).
+5. Индикатор рентабельности (success / warning / error) + выгрузка в CSV.
 
-Данные берутся из st.session_state["project_result"],
-записанного на странице 02_Project.
+Для юрисдикции «Оба» доступна конвертация валюты в сайдбаре: пользователь
+вводит курс RUB/KZT и выбирает целевую валюту — все суммы пересчитываются.
+
+Все строки интерфейса переведены на русский. Ключи результата (gross_revenue,
+direct_labor и т.п.) остаются английскими — они внутренние, часть API
+между страницами.
 """
 
+from __future__ import annotations
+
+import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
+
+from modules.jurisdiction import CURRENCY_CODES, CURRENCY_SYMBOLS
+
+
+# ---------------------------------------------------------------------------
+# Справочник русских подписей для категорий расходов Expense
+# ---------------------------------------------------------------------------
+EXPENSE_CATEGORY_LABELS: dict[str, str] = {
+    "overhead": "Накладные фирмы",
+    "disbursement_billable": "Перевыставляемый клиенту",
+    "disbursement_own": "За счёт фирмы",
+    "project_extra": "Прочие проектные расходы",
+}
+
 
 # ---------------------------------------------------------------------------
 # Заголовок
 # ---------------------------------------------------------------------------
-st.title("📊 Dashboard")
+st.title("📊 Дашборд")
 
 # ---------------------------------------------------------------------------
-# Проверяем наличие расчётных данных
+# Проверка: смета сформирована?
 # ---------------------------------------------------------------------------
 # Итерация 3: основной ключ — "results". На старых сессиях (до переименования)
 # данные могут лежать в "project_result" — fallback сохраняем для совместимости.
 r: dict | None = st.session_state.get("results") or st.session_state.get("project_result")
 if r is None:
-    st.warning("Сформируйте смету на странице **02 Project** для отображения Dashboard.")
+    st.info("Сначала сформируйте смету на странице «Проект»")
     st.stop()
 
-currency = r["currency"]
-overhead_rate_val = st.session_state.get("overhead_rate", 0.0)
 
 # ---------------------------------------------------------------------------
-# Блок KPI
+# Сайдбар: конвертация валюты для юрисдикции «Оба»
 # ---------------------------------------------------------------------------
-st.subheader(f"KPI: {r['project_name']}")
+# Логика: результат посчитан в валюте calc_country (например RUB). Если
+# пользователь выбрал «Оба», даём на дашборде отдельно переключить валюту
+# отображения и пересчитать по курсу. Множитель conv_factor применяется
+# ко всем денежным величинам; символ валюты — соответствующий.
+source_code: str = r.get("currency_code", "RUB")
+source_symbol: str = r.get("currency", CURRENCY_SYMBOLS.get(source_code[:2], "₽"))
 
-col1, col2, col3, col4 = st.columns(4)
+display_code = source_code
+display_symbol = source_symbol
+conv_factor = 1.0
 
-col1.metric(
-    label=f"Blended Rate, {currency}/ч",
-    value=f"{r['blended_rate']:,.0f}",
-    help="Взвешенная средняя ставка команды = Σ(billing × hours) / Σ(hours)",
-)
-col2.metric(
-    label="Leverage",
-    value=f"{r['leverage']:.2f}",
-    help="Часы Associate+Junior / часы Partner+Senior",
-)
-col3.metric(
-    label=f"NNE, {currency}",
-    value=f"{r['nne']:,.0f}",
-    delta=f"{(r['nne'] / r['gross_revenue'] * 100):.1f}% от выручки" if r["gross_revenue"] else None,
-    help="Net Net Effective = Gross − Labor − Overheads − Disbursements − Tax",
-)
-col4.metric(
-    label=f"Overhead Rate, {currency}/ч",
-    value=f"{overhead_rate_val:,.1f}",
-    help="Накладные фирмы / плановые оплачиваемые часы в месяц",
-)
+if r.get("jurisdiction_mode") == "Both":
+    with st.sidebar:
+        st.subheader("💱 Валюта отображения")
+        stored_rate = float(
+            st.session_state.get("exchange_rate_rub_per_kzt", 0.18)
+        )
+        rate_input = st.number_input(
+            "Курс: 1 KZT = ? RUB",
+            min_value=0.0001,
+            value=stored_rate,
+            step=0.01,
+            format="%.4f",
+            help="Например, 0.18 ₽/₸ означает «1 ₸ ≈ 0,18 ₽».",
+            key="dash_exchange_rate",
+        )
+        target_code = st.radio(
+            "Показать суммы в",
+            options=["RUB", "KZT"],
+            index=0 if source_code == "RUB" else 1,
+            horizontal=True,
+            key="dash_target_currency",
+        )
+        if st.button("🔄 Пересчитать", use_container_width=True):
+            st.session_state["display_currency_code"] = target_code
+            st.session_state["exchange_rate_rub_per_kzt"] = rate_input
 
-st.markdown("---")
-
-# ---------------------------------------------------------------------------
-# Диаграмма структуры цены (Plotly Pie)
-# ---------------------------------------------------------------------------
-st.subheader("Структура цены")
-
-labels = []
-values = []
-colors = []
-
-color_map = {
-    "Direct Labor": "#3498db",
-    "Overheads": "#9b59b6",
-    "Disbursements": "#95a5a6",
-    "Tax": "#e74c3c",
-    "NNE": "#2ecc71",
-}
-
-components = {
-    "Direct Labor": r["direct_labor"],
-    "Overheads": r["overheads_alloc"],
-    "Disbursements": r["disbursements"],
-    "Tax": r["tax"],
-    "NNE": r["nne"],
-}
-
-for name, val in components.items():
-    if val > 0:
-        labels.append(name)
-        values.append(val)
-        colors.append(color_map[name])
-
-if values:
-    fig = go.Figure(
-        data=[
-            go.Pie(
-                labels=labels,
-                values=values,
-                marker=dict(colors=colors),
-                hole=0.3,
-                textinfo="label+percent",
-                hovertemplate="%{label}: %{value:,.0f} " + currency + "<extra></extra>",
-            )
-        ]
+    display_code = st.session_state.get("display_currency_code", source_code)
+    rate_used = float(
+        st.session_state.get("exchange_rate_rub_per_kzt", stored_rate)
     )
-    fig.update_layout(
-        title=dict(text=f"Структура цены — {r['project_name']}", font=dict(size=16)),
-        legend=dict(orientation="v", x=1.05),
-        margin=dict(t=60, b=20, l=20, r=120),
-        height=500,
+
+    # Считаем коэффициент перевода из source_code в display_code:
+    # 1 KZT = rate_used RUB  →  1 RUB = 1/rate_used KZT.
+    if display_code == source_code:
+        conv_factor = 1.0
+    elif source_code == "RUB" and display_code == "KZT":
+        conv_factor = 1.0 / rate_used if rate_used > 0 else 1.0
+    elif source_code == "KZT" and display_code == "RUB":
+        conv_factor = rate_used
+    display_symbol = CURRENCY_SYMBOLS.get(display_code, source_symbol)
+
+
+def cx(value: float) -> float:
+    """Применяет коэффициент конвертации валют к денежной величине."""
+    return float(value) * conv_factor
+
+
+sym = display_symbol  # короткий алиас для вёрстки
+
+# ---------------------------------------------------------------------------
+# Идентификация проекта
+# ---------------------------------------------------------------------------
+st.subheader(r.get("project_name") or "Без названия")
+meta_parts: list[str] = []
+if r.get("client"):
+    meta_parts.append(f"**Клиент:** {r['client']}")
+if r.get("regime_label"):
+    meta_parts.append(f"**Режим:** {r['regime_label']}")
+if meta_parts:
+    st.caption("  ·  ".join(meta_parts))
+
+# ---------------------------------------------------------------------------
+# Блок 1 — Карточки верхнего уровня
+# ---------------------------------------------------------------------------
+gross = cx(r["gross_revenue"])
+disb_b = cx(r["disbursements"])
+total_client = cx(r.get("total_client", r["gross_revenue"] + r["disbursements"]))
+nne_val = cx(r["nne"])
+
+# Перевыставляемые расходы показываем только если они ненулевые:
+# для чистого «услуги без пошлин» колонку можно спрятать.
+show_disb_col = disb_b > 0
+
+if show_disb_col:
+    c1, c2, c3, c4 = st.columns(4)
+    c1.metric(f"Выручка (без перевыст.), {sym}", f"{gross:,.0f}")
+    c2.metric(f"Перевыставляемые расходы, {sym}", f"{disb_b:,.0f}")
+    c3.metric(f"Итоговый счёт клиенту, {sym}", f"{total_client:,.0f}")
+    c4.metric(
+        f"Чистая прибыль (NNE), {sym}",
+        f"{nne_val:,.0f}",
+        delta=(
+            f"{(nne_val / total_client * 100):.1f}% маржи"
+            if total_client
+            else None
+        ),
     )
-    st.plotly_chart(fig, use_container_width=True)
 else:
-    st.info("Нет данных для построения диаграммы.")
+    c1, c2, c3 = st.columns(3)
+    c1.metric(f"Выручка, {sym}", f"{gross:,.0f}")
+    c2.metric(f"Итоговый счёт клиенту, {sym}", f"{total_client:,.0f}")
+    c3.metric(
+        f"Чистая прибыль (NNE), {sym}",
+        f"{nne_val:,.0f}",
+        delta=(
+            f"{(nne_val / total_client * 100):.1f}% маржи"
+            if total_client
+            else None
+        ),
+    )
 
 st.markdown("---")
 
+
 # ---------------------------------------------------------------------------
-# Детальная таблица финансового результата
+# Блок 2 — Структура цены + вспомогательные метрики
 # ---------------------------------------------------------------------------
-st.subheader("Финансовый результат")
+col_chart, col_metrics = st.columns([1.4, 1])
 
-summary_data = {
-    "Показатель": [
-        f"Выручка за услуги, {currency}",
-        f"Пошлины (транзит), {currency}",
-        f"Итого для клиента, {currency}",
-        "",
-        f"Direct Labor, {currency}",
-        f"Overheads alloc., {currency}",
-        f"Disbursements (own), {currency}",
-        f"Налог, {currency}",
-        "",
-        f"NNE, {currency}",
-        "Маржа NNE, %",
-    ],
-    "Значение": [
-        f"{r['gross_revenue']:,.0f}",
-        f"{r['disbursements']:,.0f}",
-        f"{r['total_client']:,.0f}",
-        "",
-        f"{r['direct_labor']:,.0f}",
-        f"{r['overheads_alloc']:,.0f}",
-        f"{r.get('disbursements_own', 0):,.0f}",
-        f"{r['tax']:,.0f}",
-        "",
-        f"{r['nne']:,.0f}",
-        f"{(r['nne'] / r['gross_revenue'] * 100):.1f}%" if r["gross_revenue"] else "—",
-    ],
-}
+with col_chart:
+    st.markdown("#### Структура цены")
 
-import pandas as pd
-st.dataframe(
-    pd.DataFrame(summary_data),
-    use_container_width=True,
-    hide_index=True,
-)
+    # Секции в рублёвом эквиваленте и с русскими подписями.
+    # Ноль и отрицательные значения в диаграмму не включаем.
+    chart_sections: list[tuple[str, float, str]] = [
+        ("Прямые трудозатраты",    cx(r["direct_labor"]),        "#3498db"),
+        ("Накладные (распределённые)", cx(r["overheads_alloc"]), "#9b59b6"),
+        ("Налог",                  cx(r["tax"]),                 "#e74c3c"),
+        ("Расходы за счёт фирмы",  cx(r["disbursements_own"]),   "#95a5a6"),
+        ("Чистая прибыль (NNE)",   nne_val,                      "#2ecc71"),
+    ]
+    labels = [name for name, val, _ in chart_sections if val > 0]
+    values = [val for _, val, _ in chart_sections if val > 0]
+    colors = [clr for _, val, clr in chart_sections if val > 0]
 
-st.caption(
-    "NNE = Gross Revenue − Direct Labor − Overheads Alloc. − Disbursements (own) − Tax  |  "
-    "Методология: Mayster, «Managing the Professional Service Firm»"
-)
+    if values:
+        fig = go.Figure(
+            data=[
+                go.Pie(
+                    labels=labels,
+                    values=values,
+                    marker=dict(colors=colors),
+                    hole=0.35,
+                    textinfo="label+percent",
+                    hovertemplate="%{label}: %{value:,.0f} " + sym + "<extra></extra>",
+                )
+            ]
+        )
+        fig.update_layout(
+            margin=dict(t=10, b=10, l=10, r=10),
+            height=400,
+            showlegend=True,
+            legend=dict(orientation="h", yanchor="top", y=-0.05),
+        )
+        st.plotly_chart(fig, use_container_width=True)
+    else:
+        st.info("Все статьи нулевые — структуру цены построить нельзя.")
+
+    st.caption(f"Налоговый режим: {r.get('regime_label', '—')}")
+
+with col_metrics:
+    st.markdown("#### Показатели")
+
+    overhead_rate_val = float(
+        r.get("overhead_rate", st.session_state.get("overhead_rate", 0.0))
+    )
+
+    # Эффективная ставка = налог / выручка (с учётом перевыставляемых — это
+    # «итоговый счёт клиенту»; именно на эту сумму клиент смотрит).
+    effective_rate = 0.0
+    if total_client > 0:
+        effective_rate = cx(r["tax"]) / total_client * 100
+
+    st.metric(
+        f"Средневзвешенная ставка, {sym}/ч",
+        f"{cx(r['blended_rate']):,.0f}",
+        help="Σ(billing × hours) / Σ(hours). С учётом валюты отображения.",
+    )
+    st.metric(
+        "Коэффициент рычага",
+        f"{r['leverage']:.2f}",
+        help="Часы младших / часы старших. Выше — выше маржинальность.",
+    )
+    st.metric(
+        f"Ставка накладных, {sym}/ч",
+        f"{cx(overhead_rate_val):,.1f}",
+        help="Σ(месячных накладных) / billable_hours_per_month.",
+    )
+    st.metric(
+        "Эффективная ставка налога",
+        f"{effective_rate:.1f}%",
+        help=f"Налог / итоговый счёт. Базовый режим: {r.get('regime_label', '—')}.",
+    )
+
+st.markdown("---")
+
+
+# ---------------------------------------------------------------------------
+# Блок 3 — Таблица по этапам
+# ---------------------------------------------------------------------------
+st.markdown("#### Этапы проекта")
+
+team_rows: list[dict] = list(r.get("team_with_hours", []))
+
+if not team_rows:
+    st.info("В смете нет этапов для отображения.")
+    stages_df = pd.DataFrame()
+else:
+    stage_rows: list[dict] = []
+    sum_hours = 0.0
+    sum_revenue = 0.0
+    sum_cost = 0.0
+    for row in team_rows:
+        hours = float(row.get("hours", 0.0))
+        billing = float(row.get("billing_rate", 0.0))
+        cost = float(row.get("cost_rate", 0.0))
+        revenue = cx(billing * hours)
+        labor_cost = cx(cost * hours)
+        margin_pct = ((revenue - labor_cost) / revenue * 100) if revenue > 0 else 0.0
+        stage_rows.append(
+            {
+                "Этап": row.get("stage_name", "—"),
+                "Исполнитель": f"{row.get('name', '—')} ({row.get('role', '—')})",
+                "Часы": f"{hours:,.1f}",
+                f"Ставка ({sym}/ч)": f"{cx(billing):,.0f}",
+                f"Выручка этапа, {sym}": f"{revenue:,.0f}",
+                "Маржа, %": f"{margin_pct:.1f}",
+            }
+        )
+        sum_hours += hours
+        sum_revenue += revenue
+        sum_cost += labor_cost
+
+    total_margin_pct = ((sum_revenue - sum_cost) / sum_revenue * 100) if sum_revenue > 0 else 0.0
+    stage_rows.append(
+        {
+            "Этап": "Итого",
+            "Исполнитель": "",
+            "Часы": f"{sum_hours:,.1f}",
+            f"Ставка ({sym}/ч)": "",
+            f"Выручка этапа, {sym}": f"{sum_revenue:,.0f}",
+            "Маржа, %": f"{total_margin_pct:.1f}",
+        }
+    )
+    stages_df = pd.DataFrame(stage_rows)
+
+    # Жирная строка итогов через pandas Styler (st.dataframe поддерживает Styler).
+    def _bold_last(row: pd.Series) -> list[str]:
+        is_total = row["Этап"] == "Итого"
+        return ["font-weight: 700" if is_total else "" for _ in row]
+
+    styled = stages_df.style.apply(_bold_last, axis=1)
+    st.dataframe(styled, use_container_width=True, hide_index=True)
+
+
+# ---------------------------------------------------------------------------
+# Блок 4 — Таблица расходов проекта (только если есть)
+# ---------------------------------------------------------------------------
+project_expenses: list[dict] = list(r.get("project_expenses", []))
+expenses_df = pd.DataFrame()
+if project_expenses:
+    st.markdown("#### Расходы проекта")
+    exp_rows = []
+    for e in project_expenses:
+        category = e.get("category", "")
+        amount = cx(float(e.get("amount", 0.0)))
+        exp_rows.append(
+            {
+                "Название": e.get("name", ""),
+                "Тип": EXPENSE_CATEGORY_LABELS.get(category, category),
+                f"Сумма, {sym}": f"{amount:,.0f}",
+                "Перевыставляется клиенту": "Да" if e.get("billable") else "Нет",
+            }
+        )
+    expenses_df = pd.DataFrame(exp_rows)
+    st.dataframe(expenses_df, use_container_width=True, hide_index=True)
+
+
+st.markdown("---")
+
+
+# ---------------------------------------------------------------------------
+# Блок 5 — Индикатор рентабельности + экспорт
+# ---------------------------------------------------------------------------
+nne_raw = float(r["nne"])  # знак не зависит от конвертации валюты
+if nne_raw > 0:
+    st.success("✅ Проект рентабелен")
+elif nne_raw == 0:
+    st.warning("⚠️ Проект в точке безубыточности")
+else:
+    st.error("❌ Проект убыточен — пересмотрите ставки или состав команды")
+
+
+# --- Скачать смету (CSV) ---
+# Собираем единый CSV: блок «Этапы», пустая строка, блок «Расходы».
+csv_parts: list[str] = []
+if not stages_df.empty:
+    csv_parts.append("# Этапы проекта")
+    csv_parts.append(stages_df.to_csv(index=False))
+if not expenses_df.empty:
+    csv_parts.append("# Расходы проекта")
+    csv_parts.append(expenses_df.to_csv(index=False))
+
+if csv_parts:
+    csv_bytes = "\n".join(csv_parts).encode("utf-8-sig")  # BOM для корректного Excel
+    file_name = f"{r.get('project_name', 'project').strip() or 'project'}_смета.csv"
+    st.download_button(
+        label="📥 Скачать смету (CSV)",
+        data=csv_bytes,
+        file_name=file_name,
+        mime="text/csv",
+        use_container_width=False,
+    )


### PR DESCRIPTION
Фиксы по ревью итерации 3:
- ExpenseManager.get_overheads_allocated переиспользует calculate_overhead_rate (DRY + защита от ZeroDivisionError внутри одного метода).
- 02_Project.py: team_by_name.get(executor) вместо next()-поиска; словарь поднят выше по коду, чтобы использоваться и в отрисовке списка, и в сборке team_with_hours.
- АУСН: новый налоговый режим РФ в TAX_RATES_RF_2026 (8% с дохода, НДС не применяется, страховые взносы 0%). Обработка в TaxCalculator._calc_rf; в 01_Setup добавлен в список режимов РФ с информационным блоком и автоматической установкой social_contributions="zero".

Новый дашборд (pages/03_Dashboard.py):
- 4 карточки верхнего уровня; колонка перевыставляемых расходов скрывается при нулевой сумме.
- Pie-диаграмма «Структура цены» + вспомогательные метрики (ставка, рычаг, накладные/ч, эффективная ставка налога) в две колонки.
- Таблица по этапам с колонкой маржи и жирной строкой итогов.
- Таблица расходов проекта (только если список непустой) с русскими подписями категорий.
- Индикатор рентабельности (success / warning / error по знаку NNE).
- Экспорт сметы в CSV (этапы + расходы, UTF-8 BOM для Excel).
- Для юрисдикции «Оба» в сайдбаре — конвертация валюты по курсу RUB/KZT с кнопкой «Пересчитать».

Русификация:
- 01_Setup: «Ставка для клиента», «Себестоимость часа», «Ставка накладных».
- 02_Project: «Средневзвешенная ставка», «Коэффициент рычага», «Выручка», «Себестоимость», «Чистая прибыль (NNE)».
- 03_Dashboard: все пользовательские подписи на русском; ключи session_state и результатов остаются английскими (внутреннее API).

Расширение results: добавлены stage_name в team_with_hours, overhead_rate и project_expenses — чтобы дашборд мог отрисовать таблицу этапов/расходов без обратного хождения в session_state.